### PR TITLE
feat: 도메인 엔티티 및 Entity 컨벤션 문서 추가

### DIFF
--- a/.agent/instructions/entity_conventions.md
+++ b/.agent/instructions/entity_conventions.md
@@ -1,0 +1,146 @@
+# Entity 작성 규칙
+
+> Rich Domain Object 패턴 가이드
+
+## Entity 책임 범위
+
+### ✅ Entity가 가져야 하는 책임
+
+| 책임                     | 예시                                   | 설명                                    |
+| ------------------------ | -------------------------------------- | --------------------------------------- |
+| **자신의 상태 변경**     | `complete()`, `drop()`, `updateName()` | Setter 대신 의미 있는 메서드명 사용     |
+| **자기 필드 기반 검증**  | `isOpen()`, `isFinished()`             | 현재 상태가 특정 조건을 만족하는지 확인 |
+| **자식 컬렉션 조작**     | `addQuestion()`, `removeQuestion()`    | Aggregate 내 자식 Entity 관리           |
+| **연관관계 편의 메서드** | `assignSurvey(survey)`                 | 양방향 관계 동기화                      |
+
+### ❌ Entity가 가지면 안 되는 책임
+
+| 피해야 할 패턴               | 이유                     | 대안                    |
+| ---------------------------- | ------------------------ | ----------------------- |
+| 다른 Aggregate Root 조회     | Entity가 Repository 의존 | Service 계층에서 처리   |
+| 외부 서비스 호출 (AI API 등) | 인프라 의존성 발생       | Service 또는 infra 계층 |
+| Repository 직접 접근         | 계층 위반                | Service 계층에서 주입   |
+| 복잡한 비즈니스 로직         | 테스트 어려움            | Domain Service 분리     |
+
+---
+
+## 상태 전이 패턴
+
+상태를 가진 Entity는 **명시적인 전이 메서드**를 제공해야 합니다.
+
+```java
+// ✅ Good: 상태 전이 규칙이 Entity 내부에 캡슐화
+public void complete() {
+    if (this.status.isFinished()) {
+        throw new IllegalStateException("이미 종료된 세션입니다.");
+    }
+    this.status = SessionStatus.COMPLETED;
+    this.endedAt = LocalDateTime.now();
+}
+
+// ❌ Bad: 외부에서 직접 상태 변경 (Setter 노출)
+session.setStatus(SessionStatus.COMPLETED);
+session.setEndedAt(LocalDateTime.now());
+```
+
+### 상태 Enum에 헬퍼 메서드 추가
+
+```java
+public enum SessionStatus {
+    IN_PROGRESS, COMPLETED, DROPPED;
+
+    public boolean isFinished() {
+        return this == COMPLETED || this == DROPPED;
+    }
+}
+```
+
+---
+
+## Aggregate 관리 패턴
+
+### 부모-자식 관계
+
+```java
+// Survey (Aggregate Root)
+@OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+private List<FixedQuestion> fixedQuestions = new ArrayList<>();
+
+// 편의 메서드로 연관관계 동기화
+public void addQuestion(FixedQuestion question) {
+    this.fixedQuestions.add(question);
+    question.assignSurvey(this);  // 양방향 동기화
+}
+
+// 외부 수정 방지 (불변 리스트 반환)
+public List<FixedQuestion> getFixedQuestions() {
+    return Collections.unmodifiableList(fixedQuestions);
+}
+```
+
+### 자식 Entity의 연관관계 메서드
+
+```java
+// FixedQuestion (자식)
+// package-private으로 외부 호출 방지
+void assignSurvey(Survey survey) {
+    this.survey = survey;
+}
+```
+
+---
+
+## 정적 팩토리 메서드
+
+복잡한 생성 로직은 정적 팩토리 메서드로 캡슐화합니다.
+
+```java
+// ✅ Good: 생성 로직 캡슐화
+public static TesterProfile createAnonymous(String ageGroup, String gender, String preferGenre) {
+    return TesterProfile.builder()
+        .testerId(UUID.randomUUID().toString())  // 자동 생성
+        .ageGroup(ageGroup)
+        .gender(gender)
+        .preferGenre(preferGenre)
+        .build();
+}
+
+// 사용
+TesterProfile profile = TesterProfile.createAnonymous("20s", "M", "RPG");
+```
+
+---
+
+## @Builder 사용 가이드
+
+```java
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // JPA 필수
+public class SurveySession {
+
+    @Builder
+    public SurveySession(Survey survey, TesterProfile testerProfile) {
+        this.survey = survey;
+        this.testerProfile = testerProfile;
+        this.status = SessionStatus.IN_PROGRESS;  // 기본값 설정
+        this.startedAt = LocalDateTime.now();
+    }
+}
+```
+
+### 주의사항
+
+- `@NoArgsConstructor(access = AccessLevel.PROTECTED)`: JPA용 기본 생성자, 외부 사용 방지
+- `@Builder`는 생성자에 적용하여 필드 선택적 제어
+- 기본값은 생성자 내부에서 설정
+
+---
+
+## 코드 리뷰 체크리스트
+
+Entity 코드 리뷰 시 확인할 항목:
+
+- [ ] Setter 메서드가 노출되어 있지 않은가?
+- [ ] 상태 변경 로직이 Entity 내부에 캡슐화되어 있는가?
+- [ ] 컬렉션이 불변 리스트로 반환되는가?
+- [ ] 연관관계 편의 메서드가 올바르게 동기화되는가?
+- [ ] `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 적용되었는가?

--- a/src/main/java/com/playprobie/api/domain/game/domain/Game.java
+++ b/src/main/java/com/playprobie/api/domain/game/domain/Game.java
@@ -1,0 +1,55 @@
+package com.playprobie.api.domain.game.domain;
+
+import com.playprobie.api.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "game")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Game extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "game_id")
+	private Long id;
+
+	@Column(name = "game_name", nullable = false)
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "game_genre")
+	private GameGenre genre;
+
+	@Column(name = "game_context", columnDefinition = "TEXT")
+	private String context;
+
+	@Builder
+	public Game(String name, GameGenre genre, String context) {
+		this.name = name;
+		this.genre = genre;
+		this.context = context;
+	}
+
+	public void update(String name, GameGenre genre, String context) {
+		this.name = name;
+		this.genre = genre;
+		this.context = context;
+	}
+
+	public void updateContext(String context) {
+		this.context = context;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/game/domain/GameGenre.java
+++ b/src/main/java/com/playprobie/api/domain/game/domain/GameGenre.java
@@ -1,0 +1,22 @@
+package com.playprobie.api.domain.game.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 게임 장르 대분류
+ */
+@Getter
+@RequiredArgsConstructor
+public enum GameGenre {
+
+    SHOOTER("슈팅", "shooter"),
+    STRATEGY("전략", "strategy"),
+    RPG("RPG", "rpg"),
+    SPORTS("스포츠", "sports"),
+    SIMULATION("시뮬레이션", "simulation"),
+    CASUAL("캐주얼", "casual");
+
+    private final String displayName;
+    private final String code;
+}

--- a/src/main/java/com/playprobie/api/domain/interview/domain/InterviewLog.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/InterviewLog.java
@@ -1,0 +1,82 @@
+package com.playprobie.api.domain.interview.domain;
+
+import java.util.Objects;
+
+import com.playprobie.api.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "interview_log", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_session_turn", columnNames = { "session_id", "turn_num" })
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = { "id" }, callSuper = false)
+public class InterviewLog extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "log_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "session_id", nullable = false)
+	private SurveySession session;
+
+	@Column(name = "fixed_q_id", nullable = false)
+	private Long fixedQuestionId;
+
+	@Column(name = "turn_num")
+	private Integer turnNum;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "q_type")
+	private QuestionType type;
+
+	@Column(name = "question_text", columnDefinition = "TEXT")
+	private String questionText;
+
+	@Column(name = "answer_text", columnDefinition = "TEXT")
+	private String answerText;
+
+	@Column(name = "tokens_used")
+	private Integer tokensUsed;
+
+	@Embedded // 분석 결과(감정, 토픽) 분리
+	private LogAnalysis analysis;
+
+	@Builder
+	public InterviewLog(SurveySession session, Long fixedQuestionId, Integer turnNum,
+			QuestionType type, String questionText, String answerText) {
+		this.session = Objects.requireNonNull(session, "InterviewLog 생성 시 session은 필수입니다");
+		this.fixedQuestionId = Objects.requireNonNull(fixedQuestionId, "InterviewLog 생성 시 fixedQuestionId는 필수입니다");
+		this.turnNum = turnNum;
+		this.type = type;
+		this.questionText = questionText;
+		this.answerText = answerText;
+	}
+
+	// 분석 결과 업데이트 (도메인 메서드)
+	public void updateAnalysis(LogAnalysis analysis, Integer tokensUsed) {
+		this.analysis = analysis;
+		this.tokensUsed = tokensUsed;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/domain/LogAnalysis.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/LogAnalysis.java
@@ -1,0 +1,26 @@
+package com.playprobie.api.domain.interview.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LogAnalysis {
+
+	@Column(name = "sentiment")
+	private String sentiment;
+
+	@Column(name = "topic_cluster")
+	private String topicCluster;
+
+	@Builder
+	public LogAnalysis(String sentiment, String topicCluster) {
+		this.sentiment = sentiment;
+		this.topicCluster = topicCluster;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/domain/QuestionType.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/QuestionType.java
@@ -1,0 +1,29 @@
+package com.playprobie.api.domain.interview.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionType {
+
+	FIXED("기획된 고정 질문"),
+	TAIL("AI 파생 꼬리 질문");
+
+	private final String description;
+
+	/**
+	 * 비즈니스 로직: 꼬리 질문 여부 확인
+	 * 서비스 계층에서 if (type == TAIL) 대신 if (type.isTail())을 사용하여 가독성 확보
+	 */
+	public boolean isTail() {
+		return this == TAIL;
+	}
+
+	/**
+	 * 비즈니스 로직: 고정 질문 여부 확인
+	 */
+	public boolean isFixed() {
+		return this == FIXED;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/domain/SessionStatus.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/SessionStatus.java
@@ -1,0 +1,30 @@
+package com.playprobie.api.domain.interview.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SessionStatus {
+
+	IN_PROGRESS("진행 중"),
+	COMPLETED("정상 완료"),
+	DROPPED("도중 이탈");
+
+	private final String description;
+
+	/**
+	 * 비즈니스 로직: 세션이 완전히 종료되었는지 확인 (성공이든 실패든)
+	 * 용도: 더 이상 대화를 진행할 수 없는 상태인지 체크할 때 사용
+	 */
+	public boolean isFinished() {
+		return this == COMPLETED || this == DROPPED;
+	}
+
+	/**
+	 * 비즈니스 로직: 현재 진행 중인지 확인
+	 */
+	public boolean isInProgress() {
+		return this == IN_PROGRESS;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/domain/SurveySession.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/SurveySession.java
@@ -1,0 +1,108 @@
+package com.playprobie.api.domain.interview.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import com.playprobie.api.domain.survey.domain.Survey;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 인터뷰 세션 Entity
+ *
+ * <p>
+ * <b>[BaseTimeEntity 미상속 이유]</b>
+ * <ul>
+ * <li>startedAt/endedAt이 비즈니스적으로 더 중요</li>
+ * <li>createdAt = startedAt으로 대체 가능</li>
+ * <li>updatedAt은 세션 특성상 의미 없음 (상태 전이만 발생)</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "survey_session")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = { "id" }, callSuper = false)
+public class SurveySession {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "session_id")
+	private Long id;
+
+	/**
+	 * 연결된 설문 (필수)
+	 *
+	 * <p>
+	 * ⚠️ LAZY 로딩: 대량 조회 시 fetch join 사용 권장
+	 * </p>
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "survey_id", nullable = false)
+	private Survey survey;
+
+	@Embedded // 테스터 정보 그룹화
+	private TesterProfile testerProfile;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status")
+	private SessionStatus status;
+
+	@Column(name = "started_at")
+	private LocalDateTime startedAt;
+
+	@Column(name = "ended_at")
+	private LocalDateTime endedAt;
+
+	@Builder
+	public SurveySession(Survey survey, TesterProfile testerProfile) {
+		this.survey = Objects.requireNonNull(survey, "SurveySession 생성 시 Survey는 필수입니다");
+		this.testerProfile = Objects.requireNonNull(testerProfile, "SurveySession 생성 시 TesterProfile은 필수입니다");
+		this.status = SessionStatus.IN_PROGRESS;
+		this.startedAt = LocalDateTime.now();
+	}
+
+	/**
+	 * 세션을 정상 완료 처리합니다.
+	 * IN_PROGRESS 상태에서만 호출 가능합니다.
+	 *
+	 * @throws IllegalStateException 이미 종료된 세션인 경우
+	 */
+	public void complete() {
+		if (this.status.isFinished()) {
+			throw new IllegalStateException("이미 종료된 세션은 완료 처리할 수 없습니다. 현재 상태: " + this.status);
+		}
+		this.status = SessionStatus.COMPLETED;
+		this.endedAt = LocalDateTime.now();
+	}
+
+	/**
+	 * 세션을 이탈(중단) 처리합니다.
+	 * IN_PROGRESS 상태에서만 호출 가능합니다.
+	 *
+	 * @throws IllegalStateException 이미 종료된 세션인 경우
+	 */
+	public void drop() {
+		if (this.status.isFinished()) {
+			throw new IllegalStateException("이미 종료된 세션은 이탈 처리할 수 없습니다. 현재 상태: " + this.status);
+		}
+		this.status = SessionStatus.DROPPED;
+		this.endedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/domain/TesterProfile.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/TesterProfile.java
@@ -1,0 +1,53 @@
+package com.playprobie.api.domain.interview.domain;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TesterProfile {
+	@Column(name = "tester_id")
+	private String testerId;
+
+	@Column(name = "tester_age_group")
+	private String ageGroup;
+
+	@Column(name = "tester_gender")
+	private String gender;
+
+	@Column(name = "tester_prefer_genre")
+	private String preferGenre;
+
+	@Builder
+	public TesterProfile(String testerId, String ageGroup, String gender, String preferGenre) {
+		this.testerId = testerId;
+		this.ageGroup = ageGroup;
+		this.gender = gender;
+		this.preferGenre = preferGenre;
+	}
+
+	/**
+	 * 비회원 테스터 프로필 생성
+	 * testerId를 자동으로 UUID로 할당합니다.
+	 *
+	 * @param ageGroup    연령대 (20s, 30s 등)
+	 * @param gender      성별 (M/F)
+	 * @param preferGenre 선호 장르
+	 * @return 새 TesterProfile 인스턴스
+	 */
+	public static TesterProfile createAnonymous(String ageGroup, String gender, String preferGenre) {
+		return TesterProfile.builder()
+				.testerId(UUID.randomUUID().toString())
+				.ageGroup(ageGroup)
+				.gender(gender)
+				.preferGenre(preferGenre)
+				.build();
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/survey/domain/FixedQuestion.java
+++ b/src/main/java/com/playprobie/api/domain/survey/domain/FixedQuestion.java
@@ -1,0 +1,46 @@
+package com.playprobie.api.domain.survey.domain;
+
+import java.util.Objects;
+
+import com.playprobie.api.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "fixed_question")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+public class FixedQuestion extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "fixed_q_id")
+	private Long id;
+
+	@Column(name = "survey_id", nullable = false)
+	private Long surveyId;
+
+	@Column(name = "q_content", columnDefinition = "TEXT")
+	private String content;
+
+	@Column(name = "q_order")
+	private Integer order;
+
+	@Builder
+	public FixedQuestion(Long surveyId, String content, Integer order) {
+		this.surveyId = Objects.requireNonNull(surveyId, "FixedQuestion 생성 시 surveyId는 필수입니다");
+		this.content = content;
+		this.order = order;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/survey/domain/Survey.java
+++ b/src/main/java/com/playprobie/api/domain/survey/domain/Survey.java
@@ -1,0 +1,70 @@
+package com.playprobie.api.domain.survey.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import com.playprobie.api.domain.game.domain.Game;
+import com.playprobie.api.global.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "survey")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Survey extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "survey_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "game_id", nullable = false)
+	private Game game;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "test_purpose")
+	private TestPurpose testPurpose;
+
+	@Column(name = "start_at")
+	private LocalDateTime startAt;
+
+	@Column(name = "end_at")
+	private LocalDateTime endAt;
+
+	@Builder
+	public Survey(Game game, TestPurpose testPurpose, LocalDateTime startAt, LocalDateTime endAt) {
+		this.game = Objects.requireNonNull(game, "Survey 생성 시 Game은 필수입니다");
+		this.testPurpose = testPurpose;
+		this.startAt = startAt;
+		this.endAt = endAt;
+	}
+
+	public boolean isOpen() {
+		if (startAt == null || endAt == null) {
+			return false;
+		}
+		LocalDateTime now = LocalDateTime.now();
+		return now.isAfter(startAt) && now.isBefore(endAt);
+	}
+
+	public void updateSchedule(LocalDateTime startAt, LocalDateTime endAt) {
+		this.startAt = startAt;
+		this.endAt = endAt;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/survey/domain/TestPurpose.java
+++ b/src/main/java/com/playprobie/api/domain/survey/domain/TestPurpose.java
@@ -1,0 +1,22 @@
+package com.playprobie.api.domain.survey.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 설문(테스트) 목적 유형
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TestPurpose {
+
+    GAMEPLAY_VALIDATION("게임성 검증", "gameplay-validation"),
+    UI_UX_FEEDBACK("UI/UX 피드백", "ui-ux-feedback"),
+    BALANCE_TESTING("밸런스 테스트", "balance-testing"),
+    STORY_EVALUATION("스토리 평가", "story-evaluation"),
+    BUG_REPORTING("버그 리포트", "bug-reporting"),
+    OVERALL_EVALUATION("종합 평가", "overall-evaluation");
+
+    private final String displayName;
+    private final String code;
+}

--- a/src/main/java/com/playprobie/api/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/playprobie/api/global/domain/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.playprobie.api.global.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #10

## ✨ 작업 내용 (Summary)
- [x] **도메인 엔티티 구현** (Rich Domain Object 패턴 적용)
  - `Game`, `GameGenre` - 게임 도메인
  - `Survey`, `FixedQuestion`, `TestPurpose` - 설문 도메인
  - `SurveySession`, `InterviewLog`, `TesterProfile`, `LogAnalysis` - 인터뷰 도메인
  - `SessionStatus`, `QuestionType` - Enum 타입
- [x] **공통 도메인 모듈 추가**
  - `BaseTimeEntity` - 생성/수정 시간 자동 관리 (`@MappedSuperclass`)
  - `TesterProfile`, `LogAnalysis` - Value Object (`@Embeddable`)
- [x] **Entity 작성 컨벤션 문서 추가**
  - [.agent/instructions/entity_conventions.md](cci:7://file:///Users/hyun/Develop/projects/play-probie/server/.agent/instructions/entity_conventions.md:0:0-0:0)

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?