### PR TITLE
feat: Spring Security 인증/비인증 엔드포인트 관리 구조 개선 (Whitelist 도입)

### DIFF
--- a/src/main/java/com/playprobie/api/global/security/SecurityConfig.java
+++ b/src/main/java/com/playprobie/api/global/security/SecurityConfig.java
@@ -56,8 +56,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // Whitelist: 인증 없이 접근 가능한 Public URL
                         .requestMatchers(SecurityConstants.PUBLIC_URLS).permitAll()
-                        // 정적 리소스 (선택적)
-                        .requestMatchers(SecurityConstants.STATIC_RESOURCES).permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated())
                 .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/playprobie/api/global/security/SecurityConstants.java
+++ b/src/main/java/com/playprobie/api/global/security/SecurityConstants.java
@@ -42,14 +42,4 @@ public final class SecurityConstants {
             "/interview/*/stream",
             "/interview/*/messages",
     };
-
-    /**
-     * 정적 리소스 URL 패턴 (선택적 사용)
-     */
-    public static final String[] STATIC_RESOURCES = {
-            "/css/**",
-            "/js/**",
-            "/images/**",
-            "/webjars/**"
-    };
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #40 

## ✨ 작업 내용 (Summary)
- [x] `SecurityConstants.java` 신규 생성
  - PUBLIC_URLS 배열로 인증 제외 URL 중앙 관리
- [x] `SecurityConfig.java` Whitelist 패턴 적용
  - 기존 하드코딩된 URL을 상수 참조로 변경
  - 유지보수성 및 가독성 향상
- [x] 인터뷰 API 비회원 접근 허용
  - `/interview/*/*`
  - `/interview/*/stream` (SSE 스트림)
  - `/interview/*/messages` (메시지 전송)
  - `/interview/{surveyId}`는 인증 필요 (차단 유지)

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- `SecurityConstants.java` 내부 문자열 Whiltelist end-point 관리

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

