### PR TITLE
fix: FastApiClient 메서드 닫는 괄호 누락 및 import 추가

### DIFF
--- a/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java
@@ -28,6 +28,7 @@ import com.playprobie.api.infra.ai.dto.response.GenerateFeedbackResponse;
 import com.playprobie.api.infra.ai.dto.response.GenerateQuestionResponse;
 import com.playprobie.api.infra.ai.dto.response.SessionEmbeddingResponse;
 import com.playprobie.api.infra.sse.dto.QuestionPayload;
+import com.playprobie.api.infra.sse.dto.payload.AnalysisPayload;
 import com.playprobie.api.infra.sse.dto.payload.ErrorPayload;
 import com.playprobie.api.infra.sse.dto.payload.StatusPayload;
 import com.playprobie.api.infra.sse.service.SseEmitterService;
@@ -398,7 +399,7 @@ public class FastApiClient implements AiClient {
 				.bodyValue(request)
 				.retrieve()
 				.bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {
-				});
+				});	}
 	/**
 	 * 꼬리질문 횟수 제한 초과 시 호출
 	 * AI 호출 없이 바로 다음 고정 질문으로 이동


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #51 

## ✨ 작업 내용 (Summary)
- [x] streamQuestionAnalysis 메서드의 닫는 괄호 누락으로 인한 컴파일 에러 수정
- [x] AnalysisPayload import 추가

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

