### PR TITLE
fix: 크로스 도메인 환경에서 JWT 쿠키 유지 문제 해결

### DIFF
--- a/src/main/java/com/playprobie/api/global/util/CookieUtils.java
+++ b/src/main/java/com/playprobie/api/global/util/CookieUtils.java
@@ -30,7 +30,7 @@ public final class CookieUtils {
                 .secure(isSecure) // HTTPS에서만 전송 (운영 환경)
                 .path("/") // 모든 경로에서 쿠키 전송
                 .maxAge(maxAgeSeconds) // 쿠키 만료 시간
-                .sameSite("Strict") // CSRF 방지
+                .sameSite(isSecure ? "Lax" : "Strict") // HTTPS: Same-Site 허용, HTTP: CSRF 방지
                 .build();
     }
 
@@ -46,7 +46,7 @@ public final class CookieUtils {
                 .secure(isSecure)
                 .path("/")
                 .maxAge(0) // 즉시 만료
-                .sameSite("Strict")
+                .sameSite(isSecure ? "Lax" : "Strict")
                 .build();
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #54 

## ✨ 작업 내용 (Summary)
- CookieUtils.java에서 SameSite 속성을 환경에 따라 동적 설정
    - HTTP (로컬): SameSite=Strict → Same-Origin CSRF 방지
    - HTTPS (dev/prod): SameSite=Lax → Same-Site 서브도메인 간 쿠키 공유 허용
- isSecure 파라미터 기반 삼항 연산자 적용
    - sameSite(isSecure ? "Lax" : "Strict")

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

