### PR TITLE
fix: 서브도메인 간 JWT 쿠키 공유를 위한 domain 속성 추가

### DIFF
--- a/src/main/java/com/playprobie/api/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/playprobie/api/domain/auth/api/AuthApi.java
@@ -35,6 +35,12 @@ public class AuthApi {
     @Value("${app.cookie.secure:false}")
     private boolean secureCookie;
 
+    /**
+     * 쿠키 도메인 (서브도메인 간 공유 시 사용, 예: .playprobie.shop)
+     */
+    @Value("${app.cookie.domain:}")
+    private String cookieDomain;
+
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = authService.signup(request);
@@ -49,7 +55,8 @@ public class AuthApi {
         ResponseCookie accessTokenCookie = CookieUtils.createAccessTokenCookie(
                 result.accessToken(),
                 result.expiresInSeconds(),
-                secureCookie);
+                secureCookie,
+                cookieDomain);
 
         // 응답 body에는 token을 포함하지 않음 (Cookie로 전송)
         LoginResponse response = LoginResponse.of(result.expiresInSeconds(), result.user());
@@ -62,7 +69,7 @@ public class AuthApi {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout() {
         // Access Token 쿠키 삭제
-        ResponseCookie deleteCookie = CookieUtils.deleteAccessTokenCookie(secureCookie);
+        ResponseCookie deleteCookie = CookieUtils.deleteAccessTokenCookie(secureCookie, cookieDomain);
 
         return ResponseEntity.noContent()
                 .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())

--- a/src/main/java/com/playprobie/api/global/util/CookieUtils.java
+++ b/src/main/java/com/playprobie/api/global/util/CookieUtils.java
@@ -22,32 +22,46 @@ public final class CookieUtils {
      * @param token         JWT 토큰
      * @param maxAgeSeconds 쿠키 만료 시간 (초)
      * @param isSecure      Secure 속성 (HTTPS 환경에서 true)
+     * @param domain        쿠키 도메인 (서브도메인 공유 시 .playprobie.shop 형태)
      * @return ResponseCookie
      */
-    public static ResponseCookie createAccessTokenCookie(String token, long maxAgeSeconds, boolean isSecure) {
-        return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, token)
+    public static ResponseCookie createAccessTokenCookie(String token, long maxAgeSeconds, boolean isSecure,
+            String domain) {
+        var builder = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, token)
                 .httpOnly(true) // JavaScript에서 접근 불가 (XSS 방지)
                 .secure(isSecure) // HTTPS에서만 전송 (운영 환경)
                 .path("/") // 모든 경로에서 쿠키 전송
                 .maxAge(maxAgeSeconds) // 쿠키 만료 시간
-                .sameSite(isSecure ? "Lax" : "Strict") // HTTPS: Same-Site 허용, HTTP: CSRF 방지
-                .build();
+                .sameSite(isSecure ? "Lax" : "Strict"); // HTTPS: Same-Site 허용, HTTP: CSRF 방지
+
+        // 도메인이 설정된 경우에만 추가 (서브도메인 간 공유)
+        if (domain != null && !domain.isBlank()) {
+            builder.domain(domain);
+        }
+
+        return builder.build();
     }
 
     /**
      * Access Token 쿠키 삭제 (로그아웃 시 사용)
      *
      * @param isSecure Secure 속성
+     * @param domain   쿠키 도메인
      * @return ResponseCookie (maxAge=0으로 삭제)
      */
-    public static ResponseCookie deleteAccessTokenCookie(boolean isSecure) {
-        return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
+    public static ResponseCookie deleteAccessTokenCookie(boolean isSecure, String domain) {
+        var builder = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
                 .httpOnly(true)
                 .secure(isSecure)
                 .path("/")
                 .maxAge(0) // 즉시 만료
-                .sameSite(isSecure ? "Lax" : "Strict")
-                .build();
+                .sameSite(isSecure ? "Lax" : "Strict");
+
+        if (domain != null && !domain.isBlank()) {
+            builder.domain(domain);
+        }
+
+        return builder.build();
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,6 +39,7 @@ aws:
 app:
   cookie:
     secure: true  # HTTPS 환경에서 Secure Cookie 사용
+    domain: .playprobie.shop  # 서브도메인 간 쿠키 공유
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -37,6 +37,7 @@ aws:
 app:
   cookie:
     secure: true  # HTTPS 환경에서 Secure Cookie 사용
+    domain: .playprobie.shop  # 서브도메인 간 쿠키 공유
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #54 

✨ 작업 내용 (Summary)
- 서브도메인 간 JWT 쿠키 공유를 위한 domain 속성 추가
- CookieUtils에 도메인 파라미터 추가 및 환경별 SameSite 동적 설정
- AuthApi에서 환경변수(app.cookie.domain)로 쿠키 도메인 주입
- application-dev.yml,  application-prod.yml에 domain: .playprobie.shop 설정
 새로고침 시 쿠키가 사라지는 문제 해결 (dev.playprobie.shop ↔ dev-api.playprobie.shop)

🚧 의존성 및 주의사항 (Dependencies) ⭐
- 프론트엔드에서 API 호출 시 credentials: 'include' 설정 필요
- CORS에서 allowCredentials(true) 설정 확인 필요

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

