### PR TITLE
refactor: 스트리밍 리소스 할당 프로세스 비동기 전환

### DIFF
--- a/src/main/java/com/playprobie/api/domain/streaming/api/StreamingResourceController.java
+++ b/src/main/java/com/playprobie/api/domain/streaming/api/StreamingResourceController.java
@@ -38,24 +38,31 @@ public class StreamingResourceController {
     private final StreamingResourceService streamingResourceService;
 
     /**
-     * 스트리밍 리소스를 할당합니다.
+     * 스트리밍 리소스를 할당합니다 (비동기).
      * 
      * <p>
      * POST /surveys/{surveyId}/streaming-resource
      * 
      * @param surveyId Survey PK
      * @param request  할당 요청
-     * @return 201 Created
+     * @return 202 Accepted (Location 헤더에 상태 조회 URL 포함)
      */
     @PostMapping
-    @Operation(summary = "스트리밍 리소스 할당", description = "GameLift 스트리밍 리소스를 할당합니다.")
+    @Operation(summary = "스트리밍 리소스 할당 (비동기)", description = "GameLift 스트리밍 리소스를 할당합니다. " +
+            "리소스 생성은 비동기로 진행되며, 응답 코드 202 Accepted와 함께 " +
+            "Location 헤더에 포함된 URL을 통해 상태를 조회해야 합니다.")
     public ResponseEntity<ApiResponse<StreamingResourceResponse>> createResource(
             @AuthenticationPrincipal(expression = "user") User user,
             @PathVariable java.util.UUID surveyId,
             @Valid @RequestBody CreateStreamingResourceRequest request) {
 
         StreamingResourceResponse response = streamingResourceService.createResource(surveyId, request, user);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(response));
+
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .location(org.springframework.web.servlet.support.ServletUriComponentsBuilder.fromCurrentRequest()
+                        .build().toUri())
+                .body(ApiResponse.of(response));
     }
 
     /**

--- a/src/main/java/com/playprobie/api/domain/streaming/application/StreamingProvisioner.java
+++ b/src/main/java/com/playprobie/api/domain/streaming/application/StreamingProvisioner.java
@@ -1,0 +1,110 @@
+package com.playprobie.api.domain.streaming.application;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.playprobie.api.domain.streaming.dao.StreamingResourceRepository;
+import com.playprobie.api.domain.streaming.domain.StreamingResource;
+import com.playprobie.api.infra.config.AwsProperties;
+import com.playprobie.api.infra.gamelift.GameLiftService;
+import com.playprobie.api.global.error.exception.BusinessException;
+import com.playprobie.api.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.gameliftstreams.model.CreateApplicationResponse;
+import software.amazon.awssdk.services.gameliftstreams.model.CreateStreamGroupResponse;
+import software.amazon.awssdk.services.gameliftstreams.model.GetStreamGroupResponse;
+import software.amazon.awssdk.services.gameliftstreams.model.StreamGroupStatus;
+
+/**
+ * 스트리밍 리소스 프로비저닝 담당 서비스 (Async).
+ * 
+ * <p>
+ * 비동기 실행을 위해 메인 서비스에서 분리되었습니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StreamingProvisioner {
+
+    private final StreamingResourceRepository streamingResourceRepository;
+    private final GameLiftService gameLiftService;
+    private final AwsProperties awsProperties;
+
+    /**
+     * 비동기로 AWS 리소스를 생성하고 연결합니다.
+     * 
+     * @param resourceId StreamingResource PK
+     */
+    @Async("taskExecutor")
+    @Transactional
+    public void provisionResourceAsync(Long resourceId) {
+        log.info("Starting async provisioning for resourceId={}", resourceId);
+
+        StreamingResource resource = streamingResourceRepository.findById(resourceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STREAMING_RESOURCE_NOT_FOUND));
+
+        try {
+            // 1. AWS Application 생성
+            String s3Uri = String.format("s3://%s/%s", awsProperties.getS3().getBucketName(),
+                    resource.getBuild().getS3Prefix());
+
+            log.info("Creating AWS Application for resourceId={}", resourceId);
+            CreateApplicationResponse appResponse = gameLiftService.createApplication(
+                    resource.getSurvey().getName() + "-app",
+                    s3Uri,
+                    resource.getBuild().getExecutablePath(),
+                    resource.getBuild().getOsType());
+
+            resource.assignApplication(appResponse.arn());
+            streamingResourceRepository.save(resource); // PROVISIONING 상태 저장
+
+            // 2. AWS StreamGroup 생성
+            log.info("Creating AWS StreamGroup for resourceId={}", resourceId);
+            CreateStreamGroupResponse groupResponse = gameLiftService.createStreamGroup(
+                    resource.getSurvey().getName() + "-group",
+                    resource.getInstanceType());
+
+            // 3. Application을 StreamGroup에 연결 (상태 안정화 대기)
+            waitForStreamGroupStable(groupResponse.arn());
+            gameLiftService.associateApplication(groupResponse.arn(), appResponse.arn());
+
+            resource.assignStreamGroup(groupResponse.arn());
+            streamingResourceRepository.save(resource); // READY 상태 저장
+
+            log.info("Async provisioning completed: resourceId={}, appArn={}, groupArn={}",
+                    resource.getId(), appResponse.arn(), groupResponse.arn());
+
+        } catch (Exception e) {
+            log.error("Async provisioning failed for resourceId={}", resourceId, e);
+            resource.markError(e.getMessage());
+            streamingResourceRepository.save(resource);
+        }
+    }
+
+    /**
+     * StreamGroup이 안정적인 상태(ACTIVATING이 아님)가 될 때까지 대기합니다.
+     */
+    private void waitForStreamGroupStable(String streamGroupId) {
+        int maxAttempts = 60;
+        for (int i = 0; i < maxAttempts; i++) {
+            GetStreamGroupResponse response = gameLiftService.getStreamGroupStatus(streamGroupId);
+            StreamGroupStatus status = response.status();
+            log.info("Waiting for StreamGroup stable: status={}, attempt={}", status, i + 1);
+
+            if (status != StreamGroupStatus.ACTIVATING) {
+                return;
+            }
+
+            try {
+                Thread.sleep(1000); // 1초 대기
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
+        }
+        log.warn("StreamGroup stability wait timed out: {}", streamGroupId);
+    }
+}

--- a/src/main/java/com/playprobie/api/domain/streaming/domain/StreamingResource.java
+++ b/src/main/java/com/playprobie/api/domain/streaming/domain/StreamingResource.java
@@ -64,7 +64,7 @@ public class StreamingResource extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 30)
-    private StreamingResourceStatus status = StreamingResourceStatus.PENDING;
+    private StreamingResourceStatus status = StreamingResourceStatus.CREATING;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "survey_id", nullable = false, unique = true)
@@ -81,7 +81,7 @@ public class StreamingResource extends BaseTimeEntity {
         this.instanceType = Objects.requireNonNull(instanceType, "StreamingResource 생성 시 instanceType은 필수입니다");
         this.maxCapacity = Objects.requireNonNull(maxCapacity, "StreamingResource 생성 시 maxCapacity는 필수입니다");
         this.osType = build.getOsType();
-        this.status = StreamingResourceStatus.PENDING;
+        this.status = StreamingResourceStatus.CREATING;
         this.currentCapacity = 0;
     }
 
@@ -156,6 +156,14 @@ public class StreamingResource extends BaseTimeEntity {
     public void terminate() {
         this.status = StreamingResourceStatus.TERMINATED;
         this.currentCapacity = 0;
+    }
+
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    public void markError(String errorMessage) {
+        this.status = StreamingResourceStatus.ERROR;
+        this.errorMessage = errorMessage;
     }
 
     /**

--- a/src/main/java/com/playprobie/api/domain/streaming/domain/StreamingResourceStatus.java
+++ b/src/main/java/com/playprobie/api/domain/streaming/domain/StreamingResourceStatus.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StreamingResourceStatus {
 
+    CREATING("생성 시작"),
     PENDING("연결 대기"),
     PROVISIONING("리소스 생성 중"),
     READY("준비 완료 (Capacity=0)"),
@@ -20,7 +21,8 @@ public enum StreamingResourceStatus {
     SCALING("확장 중"),
     ACTIVE("서비스 중 (Capacity=N)"),
     CLEANING("정리 중"),
-    TERMINATED("삭제됨");
+    TERMINATED("삭제됨"),
+    ERROR("오류 발생");
 
     private final String description;
 

--- a/src/main/java/com/playprobie/api/global/config/AsyncConfig.java
+++ b/src/main/java/com/playprobie/api/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.playprobie.api.global.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #61 

## ✨ 작업 내용 (Summary)
- [x] 504 Gateway Timeout 문제 해결을 위해 동기식 프로비저닝 로직을 비동기로 전환
- [x] StreamingProvisioner 서비스 분리 및 @Async, 트랜잭션 처리 구현
- [x] 리소스 생성 요청 시 202 Accepted 응답 및 Location 헤더 반환으로 변경
- [x] StreamingResource 엔티티에 에러 메시지 필드 및 상태(CREATING, ERROR) 추가
- [x] AsyncConfig 스레드 풀 설정 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

