### PR TITLE
feat: SSE 스트리밍 및 설문 분석 기능 개선

### DIFF
--- a/src/main/java/com/playprobie/api/domain/analytics/api/AnalyticsController.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/api/AnalyticsController.java
@@ -11,13 +11,15 @@ import com.playprobie.api.domain.analytics.application.AnalyticsService;
 import com.playprobie.api.domain.analytics.dto.QuestionResponseAnalysisWrapper;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Slf4j
 @RestController
-@RequestMapping("/api/analytics")
+@RequestMapping("/analytics")
 @RequiredArgsConstructor
 @Tag(name = "Analytics API", description = "설문 분석 결과 API")
 public class AnalyticsController {
@@ -30,10 +32,22 @@ public class AnalyticsController {
 	 */
 	@GetMapping(value = "/{surveyId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	@Operation(summary = "설문 분석 결과 스트리밍", description = "AI 분석 결과를 SSE로 스트리밍합니다.")
-	public Flux<ServerSentEvent<QuestionResponseAnalysisWrapper>> getSurveyAnalysis(
+	public Flux<ServerSentEvent<Object>> getSurveyAnalysis(
 			@PathVariable Long surveyId) {
+		log.info("📊 SSE 분석 요청 시작: surveyId={}", surveyId);
 
 		return analyticsService.getSurveyAnalysis(surveyId)
-				.map(data -> ServerSentEvent.builder(data).build());
+				.doOnNext(data -> log.info("📤 SSE 데이터 전송: questionId={}", data.fixedQuestionId()))
+				.map(data -> ServerSentEvent.builder()
+						.event("message") // 클라이언트 onmessage와 매칭
+						.data((Object) data)
+						.build())
+				// 스트림 완료 시 "complete" 이벤트 전송 (클라이언트가 정상 종료 인식)
+				.concatWith(Flux.just(ServerSentEvent.builder()
+						.event("complete")
+						.data((Object) "done") // 데이터가 있어야 브라우저에서 이벤트가 정상 발생
+						.build()))
+				.doOnComplete(() -> log.info("✅ SSE 스트림 완료: surveyId={}", surveyId))
+				.doOnError(e -> log.error("❌ SSE 스트림 에러: surveyId={}, error={}", surveyId, e.getMessage()));
 	}
 }

--- a/src/main/java/com/playprobie/api/domain/analytics/application/AnalyticsService.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/application/AnalyticsService.java
@@ -1,15 +1,25 @@
 package com.playprobie.api.domain.analytics.application;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.playprobie.api.domain.analytics.dao.QuestionResponseAnalysisRepository;
 import com.playprobie.api.domain.analytics.domain.QuestionResponseAnalysis;
 import com.playprobie.api.domain.analytics.dto.QuestionResponseAnalysisWrapper;
 import com.playprobie.api.domain.interview.dao.InterviewLogRepository;
+import com.playprobie.api.domain.interview.domain.InterviewLog;
 import com.playprobie.api.domain.survey.dao.FixedQuestionRepository;
 import com.playprobie.api.domain.survey.domain.FixedQuestion;
 import com.playprobie.api.infra.ai.AiClient;
@@ -29,23 +39,33 @@ public class AnalyticsService {
 	private final QuestionResponseAnalysisRepository questionResponseAnalysisRepository;
 	private final AiClient aiClient;
 	private final FixedQuestionRepository fixedQuestionRepository;
+	private final ObjectMapper objectMapper;
+	private final TransactionTemplate transactionTemplate;
+
+	// 동시성 제어: 동일 surveyId에 대한 중복 분석 방지
+	private final ConcurrentHashMap<Long, Boolean> analysisInProgress = new ConcurrentHashMap<>();
 
 	/**
 	 * 설문 전체 질문 분석 결과 조회 (캐시 or AI 분석)
 	 */
-	@Transactional
 	public Flux<QuestionResponseAnalysisWrapper> getSurveyAnalysis(Long surveyId) {
+		log.info("🔍 분석 요청: surveyId={}", surveyId);
 		List<FixedQuestion> questions = fixedQuestionRepository.findBySurveyIdOrderByOrderAsc(surveyId);
+		log.info("📋 조회된 질문 수: {}", questions.size());
 		if (questions.isEmpty()) {
+			log.warn("⚠️ surveyId={}에 대한 질문이 없습니다", surveyId);
 			return Flux.empty();
 		}
 
 		FixedQuestion firstQuestion = questions.get(0);
 		AnalysisCheckResult status = checkAnalysisStatus(firstQuestion);
+		log.info("📊 분석 상태: {}", status);
 
 		// FRESH 또는 IN_PROGRESS인 경우 캐시 반환
 		if (status == AnalysisCheckResult.FRESH || status == AnalysisCheckResult.IN_PROGRESS) {
-			return Flux.fromIterable(questionResponseAnalysisRepository.findAllBySurveyId(surveyId))
+			List<QuestionResponseAnalysis> cachedResults = questionResponseAnalysisRepository.findAllBySurveyId(surveyId);
+			log.info("💾 캐시된 분석 결과: {}개", cachedResults.size());
+			return Flux.fromIterable(cachedResults)
 					// 임시 분석중 데이터는 제외 (실제 결과만 반환)
 					.filter(entity -> !entity.getResultJson().contains("\"status\":\"analyzing\""))
 					.map(entity -> QuestionResponseAnalysisWrapper.builder()
@@ -53,10 +73,27 @@ public class AnalyticsService {
 							.resultJson(entity.getResultJson())
 							.build());
 		} 
-		// STALE인 경우에만 재분석
+		// STALE인 경우에만 재분석 (동시성 제어 포함)
 		else {
+			// 이미 분석 중이면 캐시 반환 (putIfAbsent는 기존 값이 없으면 null 반환)
+			if (analysisInProgress.putIfAbsent(surveyId, Boolean.TRUE) != null) {
+				log.info("🔒 이미 분석 진행 중: surveyId={}, 캐시 반환", surveyId);
+				List<QuestionResponseAnalysis> cachedResults = questionResponseAnalysisRepository.findAllBySurveyId(surveyId);
+				return Flux.fromIterable(cachedResults)
+						.filter(entity -> entity.getResultJson() != null && !entity.getResultJson().contains("\"status\":\"analyzing\""))
+						.map(entity -> QuestionResponseAnalysisWrapper.builder()
+								.fixedQuestionId(entity.getFixedQuestionId())
+								.resultJson(entity.getResultJson())
+								.build());
+			}
+
+			log.info("🔄 재분석 시작: {}개 질문", questions.size());
 			return Flux.fromIterable(questions)
-					.flatMap(question -> analyzeAndSave(surveyId, question));
+					.flatMap(question -> analyzeAndSave(surveyId, question))
+					.doFinally(signal -> {
+						analysisInProgress.remove(surveyId);
+						log.info("🔓 분석 완료, 잠금 해제: surveyId={}", surveyId);
+					});
 		}
 	}
 
@@ -97,8 +134,8 @@ public class AnalyticsService {
 	private Mono<QuestionResponseAnalysisWrapper> analyzeAndSave(Long surveyId, FixedQuestion question) {
 		int currentCount = interviewLogRepository.countByFixedQuestionIdAndAnswerTextIsNotNull(question.getId());
 
-		// 분석 시작 전에 IN_PROGRESS 상태로 변경
-		markAsInProgress(question, currentCount);
+		// 분석 시작 전에 IN_PROGRESS 상태로 변경 (별도 트랜잭션)
+		markAsInProgressWithTransaction(question, currentCount);
 
 		return aiClient.streamQuestionAnalysis(surveyId, question.getId())
 				.filter(sse -> "done".equals(sse.event()))
@@ -106,13 +143,177 @@ public class AnalyticsService {
 				.map(sse -> {
 					String resultJson = sse.data();
 					if (resultJson != null) {
-						saveOrUpdateResult(question, resultJson, currentCount);
+						resultJson = convertAnswerIdsToTexts(resultJson);
+						saveOrUpdateResultWithTransaction(question, resultJson, currentCount);
 					}
 					return QuestionResponseAnalysisWrapper.builder()
 							.fixedQuestionId(question.getId())
 							.resultJson(resultJson)
 							.build();
 				});
+	}
+	private String convertAnswerIdsToTexts(String resultJson) {
+		try {
+			JsonNode root = objectMapper.readTree(resultJson);
+			if (!root.has("clusters")) {
+				return resultJson;
+			}
+
+			ObjectNode rootNode = (ObjectNode) root;
+			ArrayNode clusters = (ArrayNode) root.get("clusters");
+
+			for (int i = 0; i < clusters.size(); i++) {
+				ObjectNode cluster = (ObjectNode) clusters.get(i);
+				if (cluster.has("representative_answer_ids")) {
+					ArrayNode answerIds = (ArrayNode) cluster.get("representative_answer_ids");
+					List<String> answerTexts = new ArrayList<>();
+
+					for (JsonNode idNode : answerIds) {
+						String answerId = idNode.asText();
+						String answerText = fetchAnswerText(answerId);
+						if (answerText != null) {
+							answerTexts.add(answerText);
+						}
+					}
+
+					// representative_answer_ids를 representative_answers로 교체
+					cluster.remove("representative_answer_ids");
+					ArrayNode answersArray = objectMapper.createArrayNode();
+					answerTexts.forEach(answersArray::add);
+					cluster.set("representative_answers", answersArray);
+				}
+			}
+
+			// outliers 섹션도 처리
+			if (root.has("outliers") && root.get("outliers").has("answer_ids")) {
+				ObjectNode outliers = (ObjectNode) root.get("outliers");
+				ArrayNode answerIds = (ArrayNode) outliers.get("answer_ids");
+				List<String> answerTexts = new ArrayList<>();
+
+				// outliers는 최대 5개만 변환 (너무 많으면 성능 이슈)
+				int limit = Math.min(answerIds.size(), 5);
+				for (int i = 0; i < limit; i++) {
+					String answerId = answerIds.get(i).asText();
+					String answerText = fetchAnswerText(answerId);
+					if (answerText != null) {
+						answerTexts.add(answerText);
+					}
+				}
+
+				ArrayNode answersArray = objectMapper.createArrayNode();
+				answerTexts.forEach(answersArray::add);
+				outliers.set("sample_answers", answersArray);
+			}
+
+			return objectMapper.writeValueAsString(rootNode);
+		} catch (Exception e) {
+			log.warn("Failed to convert answer IDs to texts: {}", e.getMessage());
+			return resultJson; // 변환 실패 시 원본 반환
+		}
+	}
+
+	/**
+	 * answer_id로부터 실제 답변 텍스트 조회
+	 * 
+	 * @param answerId 형식: {session_uuid}_{fixed_question_id}_{hash}
+	 *                 UUID는 하이픈 포함 36자 (예: ac1565f9-9b91-1346-819b-91c352bf002d_1_82c7e975)
+	 * @return 포맷팅된 대화 텍스트 (Q&A 형식)
+	 */
+	private String fetchAnswerText(String answerId) {
+		try {
+			// answer_id 형식: {uuid}_{fixedQuestionId}_{hash}
+			// UUID는 하이픈을 포함하므로 단순 split("_")으로는 파싱 불가
+			// UUID 형식: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36자)
+			
+			// 방법: 마지막 2개의 '_' 위치를 찾아서 파싱
+			int lastUnderscore = answerId.lastIndexOf('_');
+			if (lastUnderscore < 0) {
+				log.debug("Invalid answer_id format (no underscore): {}", answerId);
+				return null;
+			}
+			
+			int secondLastUnderscore = answerId.lastIndexOf('_', lastUnderscore - 1);
+			if (secondLastUnderscore < 0) {
+				log.debug("Invalid answer_id format (need at least 2 underscores): {}", answerId);
+				return null;
+			}
+			
+			// UUID 추출 (처음부터 secondLastUnderscore까지)
+			String sessionUuidStr = answerId.substring(0, secondLastUnderscore);
+			// fixedQuestionId 추출 (secondLastUnderscore+1부터 lastUnderscore까지)
+			String fixedQIdStr = answerId.substring(secondLastUnderscore + 1, lastUnderscore);
+			// hash는 무시 (lastUnderscore+1부터 끝까지)
+			
+			Long fixedQuestionId = Long.parseLong(fixedQIdStr);
+			UUID sessionUuid = UUID.fromString(sessionUuidStr);
+
+			// UUID로 InterviewLog 조회
+			List<InterviewLog> logs = interviewLogRepository
+					.findBySessionUuidAndFixedQuestionIdOrderByTurnNumAsc(sessionUuid, fixedQuestionId);
+
+			if (logs.isEmpty()) {
+				log.debug("No logs found for session_uuid={}, fixed_question_id={}", sessionUuid, fixedQuestionId);
+				return null;
+			}
+
+			// Q&A 형식으로 포맷팅
+			return logs.stream()
+					.filter(l -> l.getAnswerText() != null)
+					.map(l -> String.format("Q: %s\nA: %s", 
+							l.getQuestionText(), 
+							l.getAnswerText()))
+					.collect(Collectors.joining("\n\n"));
+		} catch (IllegalArgumentException e) {
+			log.debug("Failed to parse answer_id (invalid UUID or number): {}", answerId);
+			return null;
+		} catch (Exception e) {
+			log.warn("Unexpected error fetching answer text for id={}: {}", answerId, e.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * TransactionTemplate을 사용하여 별도 트랜잭션에서 IN_PROGRESS 표시
+	 */
+	private void markAsInProgressWithTransaction(FixedQuestion question, int count) {
+		transactionTemplate.executeWithoutResult(status -> {
+			log.info("Marking analysis as IN_PROGRESS for surveyId={}, questionId={}", question.getSurveyId(),
+					question.getId());
+
+			questionResponseAnalysisRepository.findByFixedQuestionId(question.getId())
+					.ifPresentOrElse(
+							existing -> {
+								existing.markInProgress();
+								questionResponseAnalysisRepository.save(existing);
+							},
+							() -> questionResponseAnalysisRepository.save(new QuestionResponseAnalysis(
+									question.getId(),
+									question.getSurveyId(),
+									"{\"status\":\"analyzing\"}", // 분석 진행 중 임시 JSON
+									count)));
+		});
+	}
+
+	/**
+	 * TransactionTemplate을 사용하여 별도 트랜잭션에서 결과 저장
+	 */
+	private void saveOrUpdateResultWithTransaction(FixedQuestion question, String json, int count) {
+		transactionTemplate.executeWithoutResult(status -> {
+			log.info("Saving analysis result for surveyId={}, questionId={}, count={}", question.getSurveyId(),
+					question.getId(), count);
+
+			questionResponseAnalysisRepository.findByFixedQuestionId(question.getId())
+					.ifPresentOrElse(
+							existing -> {
+								existing.updateResult(json, count);
+								questionResponseAnalysisRepository.save(existing);
+							},
+							() -> questionResponseAnalysisRepository.save(new QuestionResponseAnalysis(
+									question.getId(),
+									question.getSurveyId(),
+									json,
+									count)));
+		});
 	}
 
 	@Transactional

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/QuestionResponseAnalysisWrapper.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/QuestionResponseAnalysisWrapper.java
@@ -2,9 +2,13 @@ package com.playprobie.api.domain.analytics.dto;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.Builder;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record QuestionResponseAnalysisWrapper(
         Long fixedQuestionId,
         String resultJson) {

--- a/src/main/java/com/playprobie/api/domain/game/api/GameController.java
+++ b/src/main/java/com/playprobie/api/domain/game/api/GameController.java
@@ -68,6 +68,18 @@ public class GameController {
 		return ResponseEntity.ok(ApiResponse.of(responses));
 	}
 
+	@GetMapping("/games")
+	@Operation(summary = "내 게임 목록 조회", description = "로그인된 사용자가 접근 가능한 모든 게임 목록을 조회합니다.")
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한이 없음")
+	})
+	public ResponseEntity<ApiResponse<List<GameResponse>>> getGamesByUser(
+			@AuthenticationPrincipal(expression = "user") User user) {
+		List<GameResponse> responses = gameService.getGamesByUser(user);
+		return ResponseEntity.ok(ApiResponse.of(responses));
+	}
+
 	@GetMapping("/games/{gameUuid}")
 	@Operation(summary = "게임 상세 조회", description = "게임 상세 정보를 조회합니다.")
 	@ApiResponses({

--- a/src/main/java/com/playprobie/api/domain/game/application/GameService.java
+++ b/src/main/java/com/playprobie/api/domain/game/application/GameService.java
@@ -59,6 +59,13 @@ public class GameService {
 				.toList();
 	}
 
+	public List<GameResponse> getGamesByUser(User user) {
+		List<Game> games = gameRepository.findByWorkspace_Members_User_Id(user.getId());
+		return games.stream()
+				.map(GameResponse::from)
+				.toList();
+	}
+
 	public GameResponse getGame(Long gameId, User user) {
 		Game game = getGameEntity(gameId, user);
 		return GameResponse.from(game);

--- a/src/main/java/com/playprobie/api/domain/game/dao/GameRepository.java
+++ b/src/main/java/com/playprobie/api/domain/game/dao/GameRepository.java
@@ -12,4 +12,7 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     Optional<Game> findByUuid(UUID uuid);
 
     List<Game> findByWorkspaceUuid(UUID workspaceUuid);
+
+    @org.springframework.data.jpa.repository.Query("SELECT g FROM Game g JOIN g.workspace w JOIN w.members m WHERE m.user.id = :userId")
+    List<Game> findByWorkspace_Members_User_Id(@org.springframework.data.repository.query.Param("userId") Long userId);
 }

--- a/src/main/java/com/playprobie/api/domain/interview/dao/InterviewLogRepository.java
+++ b/src/main/java/com/playprobie/api/domain/interview/dao/InterviewLogRepository.java
@@ -33,4 +33,15 @@ public interface InterviewLogRepository extends JpaRepository<InterviewLog, Long
 
         // 특정 고정 질문에 대한 총 답변 개수 (NULL 제외)
         int countByFixedQuestionIdAndAnswerTextIsNotNull(Long fixedQuestionId);
+
+        // 특정 세션 + 고정질문의 모든 로그 조회 (대표 답변 조회용)
+        List<InterviewLog> findBySessionIdAndFixedQuestionIdOrderByTurnNumAsc(Long sessionId, Long fixedQuestionId);
+
+        // UUID 버전 (Analytics 대표 답변 조회용)
+        @org.springframework.data.jpa.repository.Query("SELECT il FROM InterviewLog il " +
+                        "WHERE il.session.uuid = :sessionUuid AND il.fixedQuestionId = :fixedQuestionId " +
+                        "ORDER BY il.turnNum ASC")
+        List<InterviewLog> findBySessionUuidAndFixedQuestionIdOrderByTurnNumAsc(
+                        @org.springframework.data.repository.query.Param("sessionUuid") UUID sessionUuid,
+                        @org.springframework.data.repository.query.Param("fixedQuestionId") Long fixedQuestionId);
 }

--- a/src/main/java/com/playprobie/api/domain/survey/api/SurveyResultApi.java
+++ b/src/main/java/com/playprobie/api/domain/survey/api/SurveyResultApi.java
@@ -1,7 +1,9 @@
 package com.playprobie.api.domain.survey.api;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.playprobie.api.domain.user.domain.User;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,7 +15,6 @@ import com.playprobie.api.domain.survey.application.SurveyResultService;
 import com.playprobie.api.domain.survey.dto.SurveyResultDetailResponse;
 import com.playprobie.api.domain.survey.dto.SurveyResultListResponse;
 import com.playprobie.api.domain.survey.dto.SurveyResultSummaryResponse;
-import com.playprobie.api.domain.user.domain.User;
 import com.playprobie.api.global.common.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,7 +51,7 @@ public class SurveyResultApi {
     @GetMapping("/{surveyUuid}/details/{sessionUuid}")
     @Operation(summary = "설문 응답 상세 조회", description = "특정 세션의 설문 응답 상세 내용을 조회합니다.")
     public ResponseEntity<ApiResponse<SurveyResultDetailResponse>> getResponseDetails(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal(expression = "user") User user,
             @PathVariable java.util.UUID surveyUuid,
             @PathVariable java.util.UUID sessionUuid) {
         return ResponseEntity.ok(ApiResponse.of(surveyResultService.getResponseDetails(surveyUuid, sessionUuid, user)));

--- a/src/main/java/com/playprobie/api/domain/survey/dto/SurveyResultDetailResponse.java
+++ b/src/main/java/com/playprobie/api/domain/survey/dto/SurveyResultDetailResponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.playprobie.api.domain.interview.domain.QuestionType;
 import com.playprobie.api.domain.interview.domain.SessionStatus;
 
@@ -15,6 +17,7 @@ import lombok.Getter;
 @Schema(description = "설문 결과 상세 응답 DTO")
 @Getter
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SurveyResultDetailResponse {
 
     @Schema(description = "세션 정보")
@@ -26,6 +29,7 @@ public class SurveyResultDetailResponse {
     @Schema(description = "세션 정보")
     @Getter
     @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class SessionInfo {
         @Schema(description = "세션 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
         private UUID sessionUuid;
@@ -50,6 +54,7 @@ public class SurveyResultDetailResponse {
     @Schema(description = "고정 질문 그룹")
     @Getter
     @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class FixedQuestionGroup {
         @Schema(description = "고정 질문 내용", example = "게임 그래픽은 어떠셨나요?")
         private String fixedQuestion;
@@ -61,6 +66,7 @@ public class SurveyResultDetailResponse {
     @Schema(description = "응답 발췌 항목")
     @Getter
     @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class ExcerptItem {
         @Schema(description = "질문 유형 (FIXED, AI)", example = "FIXED")
         private QuestionType qType;

--- a/src/main/java/com/playprobie/api/domain/survey/dto/SurveyResultListResponse.java
+++ b/src/main/java/com/playprobie/api/domain/survey/dto/SurveyResultListResponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.playprobie.api.domain.interview.domain.SessionStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,41 +16,33 @@ import lombok.Getter;
 @Schema(description = "설문 결과 목록 응답 DTO")
 @Getter
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SurveyResultListResponse {
 
-    @Schema(description = "세션 목록")
-    private List<SessionItem> content;
+        private List<SessionItem> content;
 
-    @Schema(description = "다음 페이지 커서", example = "10")
-    private Long nextCursor;
+        @Schema(description = "다음 페이지 커서", example = "10")
+        private Long nextCursor;
 
-    @Schema(description = "다음 페이지 존재 여부", example = "true")
-    private boolean hasNext;
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private boolean hasNext;
 
-    @Schema(description = "세션 항목")
-    @Getter
-    @Builder
-    public static class SessionItem {
-        @Schema(description = "세션 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
-        private UUID sessionUuid;
+        @Getter
+        @Builder
+        public static class SessionItem {
+                private java.util.UUID sessionUuid;
+                private String surveyName;
 
-        @Schema(description = "설문 이름", example = "출시 전 테스트 설문")
-        private String surveyName;
+                @Schema(description = "설문 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+                private UUID surveyUuid;
 
-        @Schema(description = "설문 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
-        private UUID surveyUuid;
+                @Schema(description = "테스터 ID", example = "tester123")
+                private String testerId;
+                private SessionStatus status;
+                private String firstQuestion;
 
-        @Schema(description = "테스터 ID", example = "tester123")
-        private String testerId;
-
-        @Schema(description = "세션 상태 (ACTIVE, COMPLETED, TIMEOUT, ERROR)", example = "COMPLETED")
-        private SessionStatus status;
-
-        @Schema(description = "첫 번째 질문", example = "게임 그래픽은 어떠셨나요?")
-        private String firstQuestion;
-
-        @Schema(description = "종료 일시", example = "2024-01-01T10:30:00+09:00", type = "string")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
-        private OffsetDateTime endedAt;
-    }
+                @Schema(description = "종료 일시", example = "2024-01-01T10:30:00+09:00", type = "string")
+                @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
+                private OffsetDateTime endedAt;
+        }
 }

--- a/src/main/java/com/playprobie/api/domain/survey/dto/SurveyResultSummaryResponse.java
+++ b/src/main/java/com/playprobie/api/domain/survey/dto/SurveyResultSummaryResponse.java
@@ -1,5 +1,8 @@
 package com.playprobie.api.domain.survey.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +10,7 @@ import lombok.Getter;
 @Schema(description = "설문 결과 요약 응답 DTO")
 @Getter
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SurveyResultSummaryResponse {
 
     @Schema(description = "총 설문 수", example = "10")

--- a/src/main/java/com/playprobie/api/domain/workspace/domain/Workspace.java
+++ b/src/main/java/com/playprobie/api/domain/workspace/domain/Workspace.java
@@ -56,7 +56,8 @@ public class Workspace extends BaseTimeEntity {
     private List<WorkspaceMember> members = new ArrayList<>();
 
     @Builder
-    public Workspace(String name, String profileImageUrl, String description) {
+    public Workspace(UUID uuid, String name, String profileImageUrl, String description) {
+        this.uuid = uuid;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.description = description;

--- a/src/main/java/com/playprobie/api/global/config/WebClientConfig.java
+++ b/src/main/java/com/playprobie/api/global/config/WebClientConfig.java
@@ -3,8 +3,15 @@ package com.playprobie.api.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@Slf4j
 @Configuration
 public class WebClientConfig {
 
@@ -13,8 +20,29 @@ public class WebClientConfig {
 
 	@Bean
 	public WebClient aiWebClient() {
+		HttpClient httpClient = HttpClient.create()
+				.option(io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS, 30000) // 30초 연결 타임아웃
+				.responseTimeout(java.time.Duration.ofSeconds(300)); // 5분 응답 타임아웃
+
 		return WebClient.builder()
-			.baseUrl(aiServerURl)
-			.build();
+				.baseUrl(aiServerURl)
+				.clientConnector(new ReactorClientHttpConnector(httpClient))
+				.filter(logRequest())
+				.filter(logResponse())
+				.build();
+	}
+
+	private ExchangeFilterFunction logRequest() {
+		return ExchangeFilterFunction.ofRequestProcessor(request -> {
+			log.info("🌐 WebClient Request: {} {}", request.method(), request.url());
+			return Mono.just(request);
+		});
+	}
+
+	private ExchangeFilterFunction logResponse() {
+		return ExchangeFilterFunction.ofResponseProcessor(response -> {
+			log.info("🌐 WebClient Response: status={}", response.statusCode());
+			return Mono.just(response);
+		});
 	}
 }

--- a/src/main/java/com/playprobie/api/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/playprobie/api/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.playprobie.api.global.error;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,6 +17,19 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+	/**
+	 * HttpMediaTypeNotAcceptableException 처리
+	 * SSE 스트리밍 등에서 Content-Type 협상 실패 시 발생
+	 */
+	@ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+	protected ResponseEntity<String> handleHttpMediaTypeNotAcceptableException(HttpMediaTypeNotAcceptableException e) {
+		log.warn("handleHttpMediaTypeNotAcceptableException: {}", e.getMessage());
+		// JSON이 아닌 plain text로 응답하여 협상 실패 방지
+		return ResponseEntity
+				.status(HttpStatus.NOT_ACCEPTABLE)
+				.body("Media type not acceptable: " + e.getMessage());
+	}
 
 	/**
 	 * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.

--- a/src/main/java/com/playprobie/api/global/security/SecurityConstants.java
+++ b/src/main/java/com/playprobie/api/global/security/SecurityConstants.java
@@ -41,5 +41,6 @@ public final class SecurityConstants {
             "/interview/*/*",
             "/interview/*/stream",
             "/interview/*/messages",
+
     };
 }

--- a/src/main/java/com/playprobie/api/infra/ai/AiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/AiClient.java
@@ -9,7 +9,10 @@ import com.playprobie.api.infra.ai.dto.request.GenerateFeedbackRequest;
 import com.playprobie.api.infra.ai.dto.request.SessionEmbeddingRequest;
 import com.playprobie.api.infra.ai.dto.response.GenerateFeedbackResponse;
 
+import com.playprobie.api.infra.ai.dto.response.SessionEmbeddingResponse;
+
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * AI 클라이언트 인터페이스
@@ -39,7 +42,10 @@ public interface AiClient {
         void streamNextQuestion(String sessionId, UserAnswerRequest userAnswerRequest);
 
         // 세션 완료 시 임베딩 요청 (비동기)
-        void embedSessionData(SessionEmbeddingRequest request);
+        Mono<SessionEmbeddingResponse> embedSessionData(SessionEmbeddingRequest request);
+
+        // 질문 분석 수동 트리거 (Mock 데이터 등에서 사용)
+        void triggerAnalysis(Long surveyId, Long fixedQuestionId);
 
         // 질문 분석 요청 (SSE 스트리밍)
         Flux<ServerSentEvent<String>> streamQuestionAnalysis(Long surveyId, Long fixedQuestionId);

--- a/src/main/java/com/playprobie/api/infra/ai/dto/request/SessionEmbeddingRequest.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/request/SessionEmbeddingRequest.java
@@ -21,7 +21,9 @@ public record SessionEmbeddingRequest(
 
         @Schema(description = "QA 쌍 목록") @JsonProperty("qa_pairs") List<QaPair> qaPairs,
 
-        @Schema(description = "추가 메타데이터") @JsonProperty("metadata") Object metadata) {
+        @Schema(description = "추가 메타데이터") @JsonProperty("metadata") Object metadata,
+
+        @Schema(description = "분석 자동 트리거 여부", example = "true") @com.fasterxml.jackson.annotation.JsonIgnore Boolean autoTriggerAnalysis) {
 
     @Schema(description = "질문-답변 쌍")
     @Builder

--- a/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java
@@ -28,7 +28,6 @@ import com.playprobie.api.infra.ai.dto.response.GenerateFeedbackResponse;
 import com.playprobie.api.infra.ai.dto.response.GenerateQuestionResponse;
 import com.playprobie.api.infra.ai.dto.response.SessionEmbeddingResponse;
 import com.playprobie.api.infra.sse.dto.QuestionPayload;
-import com.playprobie.api.infra.sse.dto.payload.AnalysisPayload;
 import com.playprobie.api.infra.sse.dto.payload.ErrorPayload;
 import com.playprobie.api.infra.sse.dto.payload.StatusPayload;
 import com.playprobie.api.infra.sse.service.SseEmitterService;
@@ -155,9 +154,7 @@ public class FastApiClient implements AiClient {
 					sseEmitterService.send(sessionId, "error", "AI 서버 통신 오류");
 					sseEmitterService.complete(sessionId);
 				},
-				() -> {// complete callback function
-					log.info("AI Stream completed for sessionId: {}", sessionId);
-				});
+				() -> log.info("AI Stream completed for sessionId: {}", sessionId));
 	}
 
 	private void parseAndHandleEvent(String sessionId, Long fixedQId, int nextTurnNum, String jsonStr,
@@ -240,11 +237,6 @@ public class FastApiClient implements AiClient {
 
 				nextAction.set(actionResult);
 				log.info("Analysis result - action: {}, analysis: {}", actionResult, analysis);
-
-				AnalysisPayload analysisPayload = AnalysisPayload.builder().action(actionResult).analysis(analysis)
-						.build();
-				// sseEmitterService.send(sessionId, eventType, SseResponse.of(sessionId,
-				// eventType, analysisPayload));
 				break;
 
 			case "token": // 꼬리 질문 생성 중
@@ -334,10 +326,11 @@ public class FastApiClient implements AiClient {
 							.surveyId(surveyId)
 							.fixedQuestionId(fixedQuestionId)
 							.qaPairs(qaPairs)
+							.autoTriggerAnalysis(true)
 							.build();
 
 					// Embedding 요청 후 analysis 자동 트리거
-					embedSessionData(request, surveyId, fixedQuestionId);
+					embedSessionData(request, surveyId, fixedQuestionId).subscribe();
 				}
 			});
 		} catch (Exception e) {
@@ -346,43 +339,98 @@ public class FastApiClient implements AiClient {
 	}
 
 	@Override
-	public void embedSessionData(SessionEmbeddingRequest request) {
-		embedSessionData(request, request.surveyId(), request.fixedQuestionId());
+	public Mono<SessionEmbeddingResponse> embedSessionData(SessionEmbeddingRequest request) {
+		return embedSessionData(request, request.surveyId(), request.fixedQuestionId());
 	}
 
-	private void embedSessionData(SessionEmbeddingRequest request, Long surveyId, Long fixedQuestionId) {
-		aiWebClient.post()
+	private Mono<SessionEmbeddingResponse> embedSessionData(SessionEmbeddingRequest request, Long surveyId,
+			Long fixedQuestionId) {
+		log.debug("📡 Embedding 요청 준비: session={}, fixedQId={}", request.sessionId(), fixedQuestionId);
+		return aiWebClient.post()
 				.uri("/embeddings")
 				.contentType(MediaType.APPLICATION_JSON)
 				.bodyValue(request)
 				.retrieve()
+				.onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+						response -> response.bodyToMono(String.class)
+								.flatMap(body -> {
+									log.error("❌ AI 서버 에러 응답: status={}, body={}", response.statusCode(), body);
+									return reactor.core.publisher.Mono.error(
+											new RuntimeException(
+													"AI Server Error: " + response.statusCode() + " - " + body));
+								}))
 				.bodyToMono(SessionEmbeddingResponse.class)
-				.subscribe(
+				.timeout(java.time.Duration.ofSeconds(30))
+				.doOnSubscribe(s -> log.info("📤 Embedding HTTP 요청 전송: session={}, fixedQId={}",
+						request.sessionId(), fixedQuestionId))
+				.doOnNext(result -> log.info("📥 Embedding 응답 수신: session={}, fixedQId={}",
+						request.sessionId(), fixedQuestionId))
+				.doOnSuccess(
 						result -> {
-							log.info("Embedding success for session: {}, fixedQId: {}, embeddingId: {}",
+							log.info("✅ Embedding success for session: {}, fixedQId: {}, embeddingId: {}",
 									request.sessionId(), fixedQuestionId, result.embeddingId());
-							// Embedding 완료 후 자동으로 analysis 트리거
-							triggerAnalysis(surveyId, fixedQuestionId);
-						},
-						error -> log.error("Embedding failed for session: {}, fixedQId: {}, error: {}",
-								request.sessionId(), fixedQuestionId, error.getMessage()));
+							// Embedding 완료 후 자동으로 analysis 트리거 (플래그 확인)
+							if (request.autoTriggerAnalysis() == null || request.autoTriggerAnalysis()) {
+								triggerAnalysis(surveyId, fixedQuestionId);
+							} else {
+								log.info("⏭️ Question {} Auto-trigger analysis skipped", fixedQuestionId);
+							}
+						})
+				.doOnError(
+						error -> log.error("❌ Embedding failed for session: {}, fixedQId: {}, error: {}",
+								request.sessionId(), fixedQuestionId, error.getMessage(), error));
 	}
 
-	private void triggerAnalysis(Long surveyId, Long fixedQuestionId) {
+	@Override
+	public void triggerAnalysis(Long surveyId, Long fixedQuestionId) {
 		try {
-			log.info("Triggering analysis for survey: {}, question: {}", surveyId, fixedQuestionId);
+			log.info("🔍 Question {} 분석 시작...", fixedQuestionId);
 			// Analysis를 비동기로 시작 (결과는 DB에 저장됨)
 			streamQuestionAnalysis(surveyId, fixedQuestionId)
 					.subscribe(
-							sse -> log.debug("Analysis progress: {}", sse.event()),
-							error -> log.error("Analysis failed for survey: {}, question: {}, error: {}",
-									surveyId, fixedQuestionId, error.getMessage()),
-							() -> log.info("Analysis completed for survey: {}, question: {}",
-									surveyId, fixedQuestionId)
-					);
+							sse -> {
+								String event = sse.event();
+								String data = sse.data();
+
+								if ("progress".equals(event) && data != null) {
+									// JSON 데이터 파싱하여 의미있는 로그 출력
+									try {
+										com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+										com.fasterxml.jackson.databind.JsonNode json = mapper.readTree(data);
+										String step = json.has("step") ? json.get("step").asText() : "unknown";
+										int progress = json.has("progress") ? json.get("progress").asInt() : 0;
+
+										String stepName = getStepName(step);
+										log.info("📊 Question {}: {} ({}%)", fixedQuestionId, stepName, progress);
+									} catch (Exception e) {
+										log.debug("Progress event: {}", data);
+									}
+								} else if ("error".equals(event)) {
+									log.error("❌ Question {} 분석 에러 이벤트: {}", fixedQuestionId, data);
+								} else if ("done".equals(event)) {
+									log.info("✅ Question {} 분석 완료!", fixedQuestionId);
+								} else {
+									log.debug("Unknown event for Question {}: {} - {}", fixedQuestionId, event, data);
+								}
+							},
+							error -> log.error("❌ Question {} 분석 실패: {}", fixedQuestionId, error.getMessage()),
+							() -> log.info("✅ Question {} 분석 스트림 종료", fixedQuestionId));
 		} catch (Exception e) {
 			log.error("Failed to trigger analysis for survey: {}, question: {}", surveyId, fixedQuestionId, e);
 		}
+	}
+
+	private String getStepName(String step) {
+		return switch (step) {
+			case "loading" -> "로딩 중";
+			case "loaded" -> "데이터 로드 완료";
+			case "reducing" -> "차원 축소 중";
+			case "clustering" -> "클러스터링 중";
+			case "extracting_keywords" -> "키워드 추출 중";
+			case "analyzing" -> "감정 분석 중";
+			case "finalizing" -> "최종 처리 중";
+			default -> step;
+		};
 	}
 
 	@Override
@@ -399,7 +447,9 @@ public class FastApiClient implements AiClient {
 				.bodyValue(request)
 				.retrieve()
 				.bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {
-				});	}
+				});
+	}
+
 	/**
 	 * 꼬리질문 횟수 제한 초과 시 호출
 	 * AI 호출 없이 바로 다음 고정 질문으로 이동


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #60 

## ✨ 작업 내용 (Summary)
- [x] Analytics API SSE 이벤트 타입 명시 및 complete 이벤트 추가
- [x] AnalyticsService에 동시성 제어 및 answer_id 변환 로직 추가
- [x] AI 답변 ID를 실제 텍스트로 변환하는 기능 구현
- [x] DTO에 snake_case JSON 직렬화 전략 적용
- [x] Game API에 사용자별 게임 목록 조회 엔드포인트 추가
- [x] AI 임베딩 요청 시 자동 분석 트리거 옵션 추가
- [x] WebClient 타임아웃 설정 및 로깅 필터 추가
- [x] SSE Content-Type 협상 에러 핸들링 추가
- [x] InterviewLogRepository에 세션 UUID 기반 조회 메서드 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

