### PR TITLE
feat: 스트리밍 종료 시 인터뷰 전환을 위한 세션 유지 기능 구현

### DIFF
--- a/src/main/java/com/playprobie/api/domain/interview/domain/SurveySession.java
+++ b/src/main/java/com/playprobie/api/domain/interview/domain/SurveySession.java
@@ -162,6 +162,17 @@ public class SurveySession {
 	}
 
 	/**
+	 * 스트리밍 세션 연결만 종료하고, 인터뷰 진행을 위해 세션을 유지합니다.
+	 * (CONNECTED -> IN_PROGRESS)
+	 */
+	public void disconnectStream() {
+		if (this.status == SessionStatus.CONNECTED) {
+			this.status = SessionStatus.IN_PROGRESS;
+			this.awsSessionId = null;
+		}
+	}
+
+	/**
 	 * 스트리밍 세션을 종료합니다.
 	 */
 	public void terminate() {

--- a/src/main/java/com/playprobie/api/domain/streaming/api/TesterSessionController.java
+++ b/src/main/java/com/playprobie/api/domain/streaming/api/TesterSessionController.java
@@ -75,7 +75,8 @@ public class TesterSessionController {
 		@Valid @RequestBody
 		TerminateSessionRequest request) {
 
-		streamingResourceService.terminateSession(surveyUuid, request.surveySessionUuid(), request.reason());
+		streamingResourceService.terminateSession(surveyUuid, request.surveySessionUuid(), request.reason(),
+			request.proceedToInterview());
 		return ResponseEntity.ok(CommonResponse.of(TerminateSessionResponse.ok()));
 	}
 }

--- a/src/main/java/com/playprobie/api/domain/streaming/dto/TerminateSessionRequest.java
+++ b/src/main/java/com/playprobie/api/domain/streaming/dto/TerminateSessionRequest.java
@@ -14,5 +14,8 @@ public record TerminateSessionRequest(
 	UUID surveySessionUuid,
 
 	@Schema(description = "종료 사유 (user_exit, timeout, error)", example = "user_exit") @JsonProperty("reason")
-	String reason) {
+	String reason,
+
+	@Schema(description = "인터뷰 진행 여부 (true: 스트리밍만 종료하고 세션 유지, false: 세션 완전 종료)", defaultValue = "false") @JsonProperty("proceed_to_interview")
+	boolean proceedToInterview) {
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #95 

## ✨ 작업 내용 (Summary)
- [x] TerminateSessionRequest에 proceed_to_interview 플래그 추가
- [x] 스트리밍 종료 시 세션을 완전히 종료하지 않고 IN_PROGRESS 상태로 전환하는 disconnectStream 로직 구현
- [x] TesterSessionController 및 StreamingResourceService에 분기 처리 추가
- [x] 기존 테스트 수정 및 전환 시나리오 검증 테스트 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

