### PR TITLE
feat: SSE를 통한 실시간 분석 결과 알림 구현

### DIFF
--- a/src/main/java/com/playprobie/api/domain/analytics/api/AnalyticsController.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/api/AnalyticsController.java
@@ -2,13 +2,16 @@ package com.playprobie.api.domain.analytics.api;
 
 import java.util.UUID;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.playprobie.api.domain.analytics.application.AnalyticsService;
+import com.playprobie.api.domain.analytics.application.AnalyticsSseService;
 import com.playprobie.api.domain.analytics.dto.AnalyticsResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AnalyticsController {
 
 	private final AnalyticsService analyticsService;
+	private final AnalyticsSseService analyticsSseService;
 
 	/**
 	 * 설문 분석 결과 조회 (REST API)
@@ -39,5 +43,12 @@ public class AnalyticsController {
 		AnalyticsResponse response = analyticsService.getSurveyAnalysis(surveyUuid);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping(value = "/{surveyUuid}/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	@Operation(summary = "분석 업데이트 구독 (SSE)")
+	public SseEmitter subscribeToUpdates(@PathVariable
+	UUID surveyUuid) {
+		return analyticsSseService.subscribe(surveyUuid);
 	}
 }

--- a/src/main/java/com/playprobie/api/domain/analytics/application/AnalyticsSseService.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/application/AnalyticsSseService.java
@@ -1,0 +1,72 @@
+package com.playprobie.api.domain.analytics.application;
+
+import com.playprobie.api.infra.sse.repository.AnalyticsSseRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsSseService {
+
+	private final AnalyticsSseRepository analyticsSseRepository;
+	private static final Long DEFAULT_TIMEOUT = 60000L; // 60초
+
+	public SseEmitter subscribe(UUID surveyUuid) {
+		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+		analyticsSseRepository.add(surveyUuid, emitter);
+
+		emitter.onCompletion(() -> analyticsSseRepository.remove(surveyUuid, emitter));
+		emitter.onTimeout(() -> {
+			log.debug("SSE connection timed out for survey: {}", surveyUuid);
+			analyticsSseRepository.remove(surveyUuid, emitter);
+		});
+		emitter.onError((e) -> {
+			log.debug("SSE connection error for survey: {}, error: {}", surveyUuid, e.getMessage());
+			analyticsSseRepository.remove(surveyUuid, emitter);
+		});
+
+		// 초기 연결 성공 이벤트
+		try {
+			emitter.send(SseEmitter.event().name("connect").data("connected"));
+		} catch (IOException e) {
+			emitter.completeWithError(e);
+		}
+
+		return emitter;
+	}
+
+	public void notifyUpdate(UUID surveyUuid) {
+		List<SseEmitter> emitters = analyticsSseRepository.findAllBySurveyUuid(surveyUuid);
+		if (emitters.isEmpty())
+			return;
+
+		log.info("📢 Broadcasting 'update' event to {} clients for survey {}", emitters.size(), surveyUuid);
+
+		emitters.forEach(emitter -> {
+			try {
+				emitter.send(SseEmitter.event().name("refresh").data("UPDATE"));
+			} catch (Exception e) {
+				analyticsSseRepository.remove(surveyUuid, emitter);
+			}
+		});
+	}
+
+	@Scheduled(fixedRate = 30000) // 30초마다 Heartbeat 전송
+	public void sendHeartbeat() {
+		analyticsSseRepository.forEach((uuid, emitter) -> {
+			try {
+				emitter.send(SseEmitter.event().name("heartbeat").data("ping"));
+			} catch (Exception e) {
+				analyticsSseRepository.remove(uuid, emitter);
+			}
+		});
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/event/AnalyticsUpdatedEvent.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/event/AnalyticsUpdatedEvent.java
@@ -1,0 +1,12 @@
+package com.playprobie.api.domain.analytics.event;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AnalyticsUpdatedEvent {
+	private final UUID surveyUuid;
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/listener/AnalyticsEventListener.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/listener/AnalyticsEventListener.java
@@ -1,0 +1,24 @@
+package com.playprobie.api.domain.analytics.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.playprobie.api.domain.analytics.application.AnalyticsSseService;
+import com.playprobie.api.domain.analytics.event.AnalyticsUpdatedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AnalyticsEventListener {
+
+	private final AnalyticsSseService analyticsSseService;
+
+	@Async // SSE 전송이 본 로직(저장)을 차단하지 않도록 비동기 처리
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleAnalyticsUpdated(AnalyticsUpdatedEvent event) {
+		analyticsSseService.notifyUpdate(event.getSurveyUuid());
+	}
+}

--- a/src/main/java/com/playprobie/api/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/playprobie/api/global/error/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.playprobie.api.global.error.exception.BusinessException;
@@ -17,6 +18,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+	/**
+	 * SSE 연결 중 클라이언트 연결 종료 시 발생하는 예외 처리
+	 * 이 예외는 정상적인 연결 종료이므로 로깅만 하고 응답하지 않음
+	 */
+	@ExceptionHandler(AsyncRequestNotUsableException.class)
+	protected void handleAsyncRequestNotUsableException(AsyncRequestNotUsableException e) {
+		log.debug("SSE connection closed by client: {}", e.getMessage());
+		// 응답 없음 (이미 연결이 끊어진 상태)
+	}
 
 	/**
 	 * HttpMediaTypeNotAcceptableException 처리

--- a/src/main/java/com/playprobie/api/global/security/SecurityConfig.java
+++ b/src/main/java/com/playprobie/api/global/security/SecurityConfig.java
@@ -48,6 +48,8 @@ public class SecurityConfig {
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
+				// SSE Async Dispatch 허용 (Heartbeat/Event 전송 시 필요)
+				.dispatcherTypeMatchers(jakarta.servlet.DispatcherType.ASYNC).permitAll()
 				// Whitelist: 인증 없이 접근 가능한 Public URL
 				.requestMatchers(SecurityConstants.PUBLIC_URLS).permitAll()
 				// 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/playprobie/api/infra/sse/repository/AnalyticsSseRepository.java
+++ b/src/main/java/com/playprobie/api/infra/sse/repository/AnalyticsSseRepository.java
@@ -1,0 +1,47 @@
+package com.playprobie.api.infra.sse.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+
+@Slf4j
+@Repository
+public class AnalyticsSseRepository {
+
+	private final Map<UUID, List<SseEmitter>> surveyEmitters = new ConcurrentHashMap<>();
+
+	public void add(UUID surveyUuid, SseEmitter emitter) {
+		List<SseEmitter> emitters = surveyEmitters.computeIfAbsent(surveyUuid, k -> new CopyOnWriteArrayList<>());
+		emitters.add(emitter);
+		log.info("SSE Emitter Added. Survey: {}, Total Clients: {}", surveyUuid, emitters.size());
+	}
+
+	public List<SseEmitter> findAllBySurveyUuid(UUID surveyUuid) {
+		return surveyEmitters.getOrDefault(surveyUuid, List.of());
+	}
+
+	public void remove(UUID surveyUuid, SseEmitter emitter) {
+		List<SseEmitter> emitters = surveyEmitters.get(surveyUuid);
+		if (emitters != null) {
+			emitters.remove(emitter);
+			if (emitters.isEmpty()) {
+				surveyEmitters.remove(surveyUuid);
+				log.info("All emitters removed for survey: {}", surveyUuid);
+			}
+		}
+	}
+
+	// Heartbeat 전송 등을 위한 전체 순회 메서드
+	public void forEach(BiConsumer<UUID, SseEmitter> action) {
+		surveyEmitters.forEach((uuid, emitters) -> {
+			emitters.forEach(emitter -> action.accept(uuid, emitter));
+		});
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #93 

## ✨ 작업 내용 (Summary)
### 추가한 파일 
- [x] AnalyticsSseService: SSE 연결 생성 및 관리, refresh 이벤트 전송, 30초 heartbeat로 연결 유지
- [x] AnalyticsSseRepository: Survey UUID별 SseEmitter 관리 (ConcurrentHashMap)
- [x] AnalyticsUpdatedEvent: 분석 완료 시 Spring Event 발행
- [x] AnalyticsEventListener: @TransactionalEventListener 와 @Async로 transaction 커밋 후 SSE 알림
### 수정한 파일
- [x] AnalyticsController: GET /{surveyUuid}/subscribe SSE 구독 엔드포인트 추가
- [x] AnalyticsService: 설문 단위 분석 완료 시 이벤트 발행 (doOnComplete)
- [x] SecurityConfig: ASYNC DispatcherType permitAll 설정 (초기만 권한 체크, 이후 SSE는 스킵)
- [x] GlobalExceptionHandler: AsyncRequestNotUsableException 핸들러 추가. (클라이언트 연결 종료 시 예외 무시)


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

