### PR TITLE
feat: 클러스터별 유저 세그먼트 분석 기능 구현

### DIFF
--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/AnswerProfile.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/AnswerProfile.java
@@ -1,0 +1,23 @@
+package com.playprobie.api.domain.analytics.dto.analysis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerProfile {
+	@JsonProperty("age_group")
+	private String ageGroup;
+
+	@JsonProperty("gender")
+	private String gender;
+
+	@JsonProperty("prefer_genre")
+	private String preferGenre;
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/ClusterInfo.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/ClusterInfo.java
@@ -1,0 +1,39 @@
+package com.playprobie.api.domain.analytics.dto.analysis;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClusterInfo {
+	private String summary;
+	private double percentage;
+	private int count;
+
+	@JsonProperty("emotion_type")
+	private String emotionType;
+
+	@JsonProperty("geq_scores")
+	private GEQScores geqScores;
+
+	@JsonProperty("emotion_detail")
+	private String emotionDetail;
+
+	@JsonProperty("answer_ids")
+	private List<String> answerIds;
+
+	private int satisfaction;
+
+	private List<String> keywords;
+
+	@JsonProperty("representative_answer_ids")
+	private List<String> representativeAnswerIds;
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/GEQScores.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/GEQScores.java
@@ -1,0 +1,26 @@
+package com.playprobie.api.domain.analytics.dto.analysis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GEQScores {
+	private int competence;
+	private int immersion;
+	private int flow;
+	private int tension;
+	private int challenge;
+
+	@JsonProperty("positive_affect")
+	private int positiveAffect;
+
+	@JsonProperty("negative_affect")
+	private int negativeAffect;
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/OutlierInfo.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/OutlierInfo.java
@@ -1,0 +1,22 @@
+package com.playprobie.api.domain.analytics.dto.analysis;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutlierInfo {
+	private int count;
+	private String summary;
+
+	@JsonProperty("answer_ids")
+	private List<String> answerIds;
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/QuestionAnalysisOutput.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/QuestionAnalysisOutput.java
@@ -1,0 +1,37 @@
+package com.playprobie.api.domain.analytics.dto.analysis;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionAnalysisOutput {
+	@JsonProperty("question_id")
+	private Long questionId;
+
+	@JsonProperty("total_answers")
+	private int totalAnswers;
+
+	private List<ClusterInfo> clusters;
+
+	private SentimentInfo sentiment;
+
+	private OutlierInfo outliers;
+
+	@JsonProperty("meta_summary")
+	private String metaSummary;
+
+	@Setter
+	@JsonProperty("answer_profiles")
+	private Map<String, AnswerProfile> answerProfiles;
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/SentimentInfo.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/SentimentInfo.java
@@ -1,0 +1,26 @@
+package com.playprobie.api.domain.analytics.dto.analysis;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentimentInfo {
+	private int score;
+	private String label;
+	private Distribution distribution;
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Distribution {
+		private double positive;
+		private double neutral;
+		private double negative;
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/dao/SurveySessionRepository.java
+++ b/src/main/java/com/playprobie/api/domain/interview/dao/SurveySessionRepository.java
@@ -16,6 +16,10 @@ public interface SurveySessionRepository extends JpaRepository<SurveySession, Lo
 
 	Optional<SurveySession> findByUuid(UUID uuid);
 
+	@Query("SELECT ss FROM SurveySession ss JOIN FETCH ss.survey WHERE ss.uuid IN :uuids")
+	List<SurveySession> findAllByUuidIn(@Param("uuids")
+	java.util.Collection<UUID> uuids);
+
 	@Query("""
 		SELECT COUNT(ss) FROM SurveySession ss
 		JOIN ss.survey s


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #106 

## ✨ 작업 내용 (Summary)
### DTO 신규 생성
- [x] 기존 데이터 DTO 생성: ClusterInfo, GEQScores, OutlierInfo, QuestionAnalysisOutput, SentimentInfo
- [x] 테스터 정보 DTO 생성: AnswerProfile
### DB검색을 통한 테스터 프로필 데이터 주입 로직 구현
- [x] AnalyticsService.java에 enrichAnalysisResult 구현
### DB검색 시 N+1 문제 해결
- [x] SurveySessionRepository에 findAllByUuidIn 구현


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

