### PR TITLE
fix: 대표 답변이 ClusterInfo DTO에 빠진 문제 해결

### DIFF
--- a/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/ClusterInfo.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/analysis/ClusterInfo.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Builder
@@ -36,4 +37,8 @@ public class ClusterInfo {
 
 	@JsonProperty("representative_answer_ids")
 	private List<String> representativeAnswerIds;
+
+	@Setter
+	@JsonProperty("representative_answers")
+	private List<String> representativeAnswers;
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #118 

## ✨ 작업 내용 (Summary)
- [x] clusterinfo DTO에 representative_answers 필드 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

