### PR TITLE
fix: SSE refresh가 전달되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/playprobie/api/domain/analytics/api/AnalyticsController.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/api/AnalyticsController.java
@@ -42,7 +42,9 @@ public class AnalyticsController {
 
 		AnalyticsResponse response = analyticsService.getSurveyAnalysis(surveyUuid);
 
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok()
+			.cacheControl(org.springframework.http.CacheControl.noCache())
+			.body(response);
 	}
 
 	@GetMapping(value = "/{surveyUuid}/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/src/main/java/com/playprobie/api/domain/analytics/application/AnalyticsSseService.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/application/AnalyticsSseService.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class AnalyticsSseService {
 
 	private final AnalyticsSseRepository analyticsSseRepository;
-	private static final Long DEFAULT_TIMEOUT = 60000L; // 60초
+	private static final Long DEFAULT_TIMEOUT = 600000L; // 10분
 
 	public SseEmitter subscribe(UUID surveyUuid) {
 		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);

--- a/src/main/java/com/playprobie/api/domain/analytics/dao/QuestionResponseAnalysisRepository.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dao/QuestionResponseAnalysisRepository.java
@@ -13,4 +13,6 @@ public interface QuestionResponseAnalysisRepository
 	Optional<QuestionResponseAnalysis> findByFixedQuestionId(Long fixedQuestionId);
 
 	List<QuestionResponseAnalysis> findAllBySurveyId(Long surveyId);
+
+	long countBySurveyIdAndStatus(Long surveyId, QuestionResponseAnalysis.AnalysisStatus status);
 }

--- a/src/main/java/com/playprobie/api/domain/analytics/dto/AnalyticsResponse.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/AnalyticsResponse.java
@@ -18,5 +18,6 @@ public record AnalyticsResponse(
 	List<QuestionResponseAnalysisWrapper> analyses,
 	String status,
 	int totalQuestions,
-	int completedQuestions) {
+	int completedQuestions,
+	int totalParticipants) {
 }

--- a/src/main/java/com/playprobie/api/domain/analytics/event/AnalysisTriggerEvent.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/event/AnalysisTriggerEvent.java
@@ -1,0 +1,17 @@
+package com.playprobie.api.domain.analytics.event;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AnalysisTriggerEvent {
+	private final String surveyUuid;
+	private final Long fixedQuestionId;
+
+	public UUID getSurveyUuidAsUUID() {
+		return UUID.fromString(surveyUuid);
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/analytics/listener/AnalyticsEventListener.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/listener/AnalyticsEventListener.java
@@ -2,23 +2,30 @@ package com.playprobie.api.domain.analytics.listener;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.playprobie.api.domain.analytics.application.AnalyticsSseService;
 import com.playprobie.api.domain.analytics.event.AnalyticsUpdatedEvent;
 
 import lombok.RequiredArgsConstructor;
+import com.playprobie.api.domain.analytics.application.AnalyticsService;
+import com.playprobie.api.domain.analytics.event.AnalysisTriggerEvent;
 
 @Component
 @RequiredArgsConstructor
 public class AnalyticsEventListener {
 
 	private final AnalyticsSseService analyticsSseService;
+	private final AnalyticsService analyticsService;
 
 	@Async // SSE 전송이 본 로직(저장)을 차단하지 않도록 비동기 처리
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@org.springframework.context.event.EventListener
 	public void handleAnalyticsUpdated(AnalyticsUpdatedEvent event) {
 		analyticsSseService.notifyUpdate(event.getSurveyUuid());
+	}
+
+	@Async
+	@org.springframework.context.event.EventListener
+	public void handleAnalysisTrigger(AnalysisTriggerEvent event) {
+		analyticsService.analyzeSingleQuestion(event.getSurveyUuidAsUUID(), event.getFixedQuestionId());
 	}
 }

--- a/src/main/java/com/playprobie/api/domain/interview/dao/SurveySessionRepository.java
+++ b/src/main/java/com/playprobie/api/domain/interview/dao/SurveySessionRepository.java
@@ -43,4 +43,6 @@ public interface SurveySessionRepository extends JpaRepository<SurveySession, Lo
 		@Param("cursor")
 		Long cursor,
 		Pageable pageable);
+
+	long countBySurveyIdAndStatus(Long surveyId, SessionStatus status);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #125 

## ✨ 작업 내용 (Summary)
- [x] SSE 타임아웃 시간을 10분으로 연장 - 테스트 중 연락이 끊기는 현상 방지
- [x] AnalyticsService, AnalyticsEventListner: transaction commit 이후 이벤트가 발생하도록 수정 - refresh요청이 lost되는 문제 해결
- [x] AnalyticsResponse, SurveySessionRepository: 완료된 세션 수를 초기 한번만 보내던 것에서 실시간으로 보내도록 수정
- [x] FastApiClient: 수정하면서 사용되지 않는 메서드 정리

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?
<img width="460" height="114" alt="refresh" src="https://github.com/user-attachments/assets/61c78574-14de-4152-9bcf-701a48722c36" />

