### PR TITLE
chore: AI 서버 타임아웃 시간 연장

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,7 +38,7 @@ ai:
     url: ${AI_SERVER_URL}
   client:
     connect-timeout: 5000ms
-    read-timeout: 10000ms
+    read-timeout: 10m
   interview:
     max-tail-questions: 2
   sse:


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #130 

## ✨ 작업 내용 (Summary)
- [x] mockdata 로딩을 위해 타임아웃 제한을 10초에서 10분으로 연장


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

