### PR TITLE
chore: AI client read-timeout을 환경변수로 분리

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -92,6 +92,7 @@ jobs:
               "echo \"AWS_GAMELIFT_REGION=${{ secrets.DEV_AWS_GAMELIFT_REGION }}\" >> /tmp/playprobie/.env",
               "echo \"AWS_GAMELIFT_ROLE_ARN=${{ secrets.DEV_AWS_GAMELIFT_ROLE_ARN }}\" >> /tmp/playprobie/.env",
               "echo \"AI_SERVER_URL=${{ secrets.DEV_AI_SERVER_URL }}\" >> /tmp/playprobie/.env",
+              "echo \"AI_CLIENT_READ_TIMEOUT=${{ secrets.AI_CLIENT_READ_TIMEOUT }}\" >> /tmp/playprobie/.env",
               "echo \"JWT_SECRET=${{ secrets.DEV_JWT_SECRET }}\" >> /tmp/playprobie/.env",
               "chmod 600 /tmp/playprobie/.env",
               "docker run -d --name playprobie-server-dev -p 8080:8080 --env-file /tmp/playprobie/.env ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}",

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -92,6 +92,7 @@ jobs:
               "echo \"AWS_GAMELIFT_REGION=${{ secrets.PROD_AWS_GAMELIFT_REGION }}\" >> /tmp/playprobie-prod/.env",
               "echo \"AWS_GAMELIFT_ROLE_ARN=${{ secrets.PROD_AWS_GAMELIFT_ROLE_ARN }}\" >> /tmp/playprobie-prod/.env",
               "echo \"AI_SERVER_URL=${{ secrets.PROD_AI_SERVER_URL }}\" >> /tmp/playprobie-prod/.env",
+              "echo \"AI_CLIENT_READ_TIMEOUT=${{ secrets.AI_CLIENT_READ_TIMEOUT }}\" >> /tmp/playprobie-prod/.env",
               "echo \"JWT_SECRET=${{ secrets.PROD_JWT_SECRET }}\" >> /tmp/playprobie-prod/.env",
               "chmod 600 /tmp/playprobie-prod/.env",
               "docker run -d --name playprobie-server-prod -p 8081:8080 --env-file /tmp/playprobie-prod/.env ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,7 +38,7 @@ ai:
     url: ${AI_SERVER_URL}
   client:
     connect-timeout: 5000ms
-    read-timeout: 10m
+    read-timeout: ${AI_CLIENT_READ_TIMEOUT}
   interview:
     max-tail-questions: 2
   sse:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,7 +38,7 @@ ai:
     url: ${AI_SERVER_URL}
   client:
     connect-timeout: 3000ms
-    read-timeout: 5000ms
+    read-timeout: ${AI_CLIENT_READ_TIMEOUT}
   interview:
     max-tail-questions: 2
   sse:


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #143 

## ✨ 작업 내용 (Summary)
- [x] application-dev, application-prod 에서 read-timeout 하드코딩 된 값을 환경변수로 수정
- [x] deploy-dev, deploy-prod에 AI_CLIENT_READ_TIMEOUT 환경변수 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] AI_CLIENT_READ_TIMEOUT 환경변수 추가

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

