### PR TITLE
feat: survey 단위 종합적 리뷰 기능 추가

### DIFF
--- a/src/main/java/com/playprobie/api/domain/analytics/dto/AnalyticsResponse.java
+++ b/src/main/java/com/playprobie/api/domain/analytics/dto/AnalyticsResponse.java
@@ -19,5 +19,6 @@ public record AnalyticsResponse(
 	String status,
 	int totalQuestions,
 	int completedQuestions,
-	int totalParticipants) {
+	int totalParticipants,
+	String surveySummary) {
 }

--- a/src/main/java/com/playprobie/api/domain/survey/domain/Survey.java
+++ b/src/main/java/com/playprobie/api/domain/survey/domain/Survey.java
@@ -77,6 +77,10 @@ public class Survey extends BaseTimeEntity {
 	@Column(name = "version_note")
 	private String versionNote;
 
+	// ===== 신규 필드 (feat/#49) =====
+	@Column(name = "survey_summary", columnDefinition = "TEXT")
+	private String surveySummary;
+
 	@Builder
 	public Survey(Game game, String name, TestPurpose testPurpose, LocalDateTime startAt, LocalDateTime endAt,
 		TestStage testStage, java.util.List<String> themePriorities,
@@ -119,6 +123,10 @@ public class Survey extends BaseTimeEntity {
 		} else {
 			this.status = status;
 		}
+	}
+
+	public void updateSurveySummary(String summary) {
+		this.surveySummary = summary;
 	}
 
 	/**

--- a/src/main/java/com/playprobie/api/infra/ai/AiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/AiClient.java
@@ -53,6 +53,15 @@ public interface AiClient {
 	Flux<ServerSentEvent<String>> streamQuestionAnalysis(String surveyUuid, Long fixedQuestionId);
 
 	/**
+	 * 설문 종합 평가 생성
+	 * POST /analytics/survey/summary
+	 *
+	 * @param questionSummaries 각 질문별 meta_summary 리스트
+	 * @return 설문 종합 평가 (1~2문장)
+	 */
+	Mono<String> generateSurveySummary(List<String> questionSummaries);
+
+	/**
 	 * AI 서버 상태 확인
 	 * GET /health
 	 *

--- a/src/main/java/com/playprobie/api/infra/ai/dto/request/SessionEmbeddingRequest.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/request/SessionEmbeddingRequest.java
@@ -29,7 +29,14 @@ public record SessionEmbeddingRequest(
 	Object metadata,
 
 	@Schema(description = "분석 자동 트리거 여부", example = "true") @com.fasterxml.jackson.annotation.JsonIgnore
-	Boolean autoTriggerAnalysis) {
+	Boolean autoTriggerAnalysis,
+
+	// === Quality Metadata ===
+	@Schema(description = "답변 유효성", example = "VALID") @JsonProperty("validity")
+	String validity,
+
+	@Schema(description = "답변 품질", example = "FULL") @JsonProperty("quality")
+	String quality) {
 
 	@Schema(description = "질문-답변 쌍")
 	@Builder

--- a/src/main/java/com/playprobie/api/infra/ai/dto/request/SurveySummaryRequest.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/request/SurveySummaryRequest.java
@@ -1,0 +1,10 @@
+package com.playprobie.api.infra.ai.dto.request;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SurveySummaryRequest(List<String> questionSummaries) {
+}

--- a/src/main/java/com/playprobie/api/infra/ai/dto/response/SurveySummaryResponse.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/response/SurveySummaryResponse.java
@@ -1,0 +1,8 @@
+package com.playprobie.api.infra.ai.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SurveySummaryResponse(String surveySummary) {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #142 

## ✨ 작업 내용 (Summary)
- [x] 각 질문별 analysis 완료 후 AI서버에게 generateSurveySummary 요청
- [x] survey dto에 survey summary 추가 및 저장
- [x] client에 analysis 결과에 survey_summary 추가해서 전송


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

