### PR TITLE
feat: 게임 요소 추출 API 구현

### DIFF
--- a/src/main/java/com/playprobie/api/domain/game/api/GameController.java
+++ b/src/main/java/com/playprobie/api/domain/game/api/GameController.java
@@ -35,6 +35,16 @@ public class GameController {
 
 	private final GameService gameService;
 
+	@PostMapping("/games/extract-elements")
+	@Operation(summary = "게임 요소 추출", description = "게임 설명에서 핵심 요소를 추출합니다.")
+	public ResponseEntity<com.playprobie.api.domain.game.dto.GameElementExtractResult> extractElements(
+		@RequestBody
+		com.playprobie.api.domain.game.dto.GameElementExtractRequest request) {
+
+		com.playprobie.api.domain.game.dto.GameElementExtractResult result = gameService.extractElements(request);
+		return ResponseEntity.ok(result);
+	}
+
 	@PostMapping("/workspaces/{workspaceUuid}/games")
 	@Operation(summary = "게임 생성", description = "특정 워크스페이스 하위에 새 게임을 생성합니다.")
 	@ApiResponses({

--- a/src/main/java/com/playprobie/api/domain/game/domain/Game.java
+++ b/src/main/java/com/playprobie/api/domain/game/domain/Game.java
@@ -43,17 +43,21 @@ public class Game extends BaseTimeEntity {
 	@Column(name = "game_context", columnDefinition = "TEXT")
 	private String context;
 
+	@Column(name = "extracted_elements", columnDefinition = "TEXT")
+	private String extractedElements;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "workspace_id")
 	private Workspace workspace;
 
 	@Builder
-	public Game(Workspace workspace, String name, List<GameGenre> genres, String context) {
+	public Game(Workspace workspace, String name, List<GameGenre> genres, String context, String extractedElements) {
 		this.uuid = java.util.UUID.randomUUID();
 		this.workspace = workspace;
 		this.name = name;
 		this.genresJson = convertGenresToJson(genres);
 		this.context = context;
+		this.extractedElements = extractedElements;
 	}
 
 	public List<GameGenre> getGenres() {
@@ -89,10 +93,11 @@ public class Game extends BaseTimeEntity {
 		return sb.toString();
 	}
 
-	public void update(String name, List<GameGenre> genres, String context) {
+	public void update(String name, List<GameGenre> genres, String context, String extractedElements) {
 		this.name = name;
 		this.genresJson = convertGenresToJson(genres);
 		this.context = context;
+		this.extractedElements = extractedElements;
 	}
 
 	public void updateContext(String context) {

--- a/src/main/java/com/playprobie/api/domain/game/dto/CreateGameRequest.java
+++ b/src/main/java/com/playprobie/api/domain/game/dto/CreateGameRequest.java
@@ -19,5 +19,8 @@ public record CreateGameRequest(
 	List<String> gameGenre,
 
 	@Schema(description = "게임 설명 (최대 2000자, 선택 사항)", example = "중세 판타지 배경의 오픈월드 RPG 게임입니다.") @Size(max = 2000, message = "게임 설명은 2000자 이하입니다") @JsonProperty("game_context")
-	String gameContext) {
+	String gameContext,
+
+	@Schema(description = "추출된 게임 요소 (JSON 문자열)", example = "{\"core_mechanic\": \"...\"}") @JsonProperty("extracted_elements")
+	String extractedElements) {
 }

--- a/src/main/java/com/playprobie/api/domain/game/dto/GameElementExtractRequest.java
+++ b/src/main/java/com/playprobie/api/domain/game/dto/GameElementExtractRequest.java
@@ -1,0 +1,13 @@
+package com.playprobie.api.domain.game.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GameElementExtractRequest(
+	String gameName,
+	List<String> genres,
+	String gameDescription) {
+}

--- a/src/main/java/com/playprobie/api/domain/game/dto/GameElementExtractResponse.java
+++ b/src/main/java/com/playprobie/api/domain/game/dto/GameElementExtractResponse.java
@@ -1,0 +1,15 @@
+package com.playprobie.api.domain.game.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GameElementExtractResponse(
+	Map<String, String> elements,
+	List<String> requiredFields,
+	List<String> optionalFields,
+	List<String> missingRequired) {
+}

--- a/src/main/java/com/playprobie/api/domain/game/dto/GameElementExtractResult.java
+++ b/src/main/java/com/playprobie/api/domain/game/dto/GameElementExtractResult.java
@@ -1,0 +1,22 @@
+package com.playprobie.api.domain.game.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GameElementExtractResult(
+	Map<String, String> elements,
+	List<String> requiredFields,
+	List<String> optionalFields,
+	List<String> missingRequired) {
+	public static GameElementExtractResult from(GameElementExtractResponse response) {
+		return new GameElementExtractResult(
+			response.elements(),
+			response.requiredFields(),
+			response.optionalFields(),
+			response.missingRequired());
+	}
+}

--- a/src/main/java/com/playprobie/api/domain/interview/api/InterviewController.java
+++ b/src/main/java/com/playprobie/api/domain/interview/api/InterviewController.java
@@ -18,7 +18,6 @@ import com.playprobie.api.domain.interview.dto.UserAnswerRequest;
 import com.playprobie.api.domain.interview.dto.UserAnswerResponse;
 import com.playprobie.api.domain.survey.dto.FixedQuestionResponse;
 import com.playprobie.api.global.common.response.CommonResponse;
-import com.playprobie.api.infra.ai.impl.FastApiClient;
 import com.playprobie.api.infra.sse.service.SseEmitterService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "Interview API", description = "인터뷰 진행 API (비회원 접근 가능)")
 public class InterviewController {
 
-	private final FastApiClient fastApiClient;
+	private final com.playprobie.api.infra.ai.AiClient fastApiClient;
 	private final SseEmitterService sseEmitterService;
 	private final InterviewService interviewService;
 

--- a/src/main/java/com/playprobie/api/infra/ai/AiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/AiClient.java
@@ -9,7 +9,6 @@ import com.playprobie.api.domain.interview.dto.UserAnswerRequest;
 import com.playprobie.api.infra.ai.dto.request.GenerateFeedbackRequest;
 import com.playprobie.api.infra.ai.dto.request.SessionEmbeddingRequest;
 import com.playprobie.api.infra.ai.dto.response.GenerateFeedbackResponse;
-
 import com.playprobie.api.infra.ai.dto.response.SessionEmbeddingResponse;
 
 import reactor.core.publisher.Flux;
@@ -39,9 +38,24 @@ public interface AiClient {
 	GenerateFeedbackResponse getQuestionFeedback(GenerateFeedbackRequest request);
 
 	/**
+	 * 게임 요소 추출 요청
+	 * POST /game/extract-elements
+	 *
+	 * @return 추출된 게임 요소 정보
+	 */
+	com.playprobie.api.domain.game.dto.GameElementExtractResponse extractGameElements(
+		com.playprobie.api.domain.game.dto.GameElementExtractRequest request);
+
+	/**
 	 * streaming 대화 토큰 전달
 	 */
 	void streamNextQuestion(String sessionId, UserAnswerRequest userAnswerRequest);
+
+	/**
+	 * 오프닝 스트리밍 (세션 시작)
+	 */
+	void streamOpening(String sessionId, Map<String, Object> gameInfo,
+		com.playprobie.api.infra.ai.dto.request.AiSessionStartRequest.TesterProfileDto testerProfile);
 
 	// 세션 완료 시 임베딩 요청 (비동기)
 	Mono<SessionEmbeddingResponse> embedSessionData(SessionEmbeddingRequest request);

--- a/src/test/java/com/playprobie/api/domain/game/api/GameExtractionIntegrationTest.java
+++ b/src/test/java/com/playprobie/api/domain/game/api/GameExtractionIntegrationTest.java
@@ -1,0 +1,151 @@
+package com.playprobie.api.domain.game.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playprobie.api.domain.game.dao.GameRepository;
+import com.playprobie.api.domain.game.domain.Game;
+import com.playprobie.api.domain.game.dto.CreateGameRequest;
+import com.playprobie.api.domain.game.dto.GameElementExtractRequest;
+import com.playprobie.api.domain.game.dto.GameElementExtractResponse;
+import com.playprobie.api.domain.user.dao.UserRepository;
+import com.playprobie.api.domain.user.domain.User;
+import com.playprobie.api.domain.workspace.dao.WorkspaceMemberRepository;
+import com.playprobie.api.domain.workspace.dao.WorkspaceRepository;
+import com.playprobie.api.domain.workspace.domain.Workspace;
+import com.playprobie.api.domain.workspace.domain.WorkspaceMember;
+import com.playprobie.api.domain.workspace.domain.WorkspaceRole;
+import com.playprobie.api.global.security.CustomUserDetails;
+import com.playprobie.api.infra.ai.AiClient;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class GameExtractionIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private WorkspaceRepository workspaceRepository;
+
+	@Autowired
+	private WorkspaceMemberRepository workspaceMemberRepository;
+
+	@Autowired
+	private GameRepository gameRepository;
+
+	@MockitoBean
+	private AiClient aiClient;
+
+	private User testUser;
+	private Workspace testWorkspace;
+
+	@BeforeEach
+	void setUp() {
+		// User & Workspace setup
+		testUser = userRepository.save(User.builder()
+			.email("test@example.com")
+			.password("password")
+			.name("Test User")
+			.build());
+
+		testWorkspace = workspaceRepository.save(Workspace.create("Test Workspace", "Desc"));
+
+		workspaceMemberRepository.save(WorkspaceMember.builder()
+			.workspace(testWorkspace)
+			.user(testUser)
+			.role(WorkspaceRole.OWNER)
+			.build());
+
+		// Security Context
+		CustomUserDetails userDetails = new CustomUserDetails(testUser);
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+	}
+
+	@Test
+	@DisplayName("POST /games/extract-elements - 성공적으로 요소를 추출해야 함")
+	void extractElements_Success() throws Exception {
+		// given
+		GameElementExtractRequest request = new GameElementExtractRequest(
+			"Test Game",
+			List.of("Action"),
+			"A game where you fight.");
+
+		GameElementExtractResponse mockResponse = new GameElementExtractResponse(
+			Map.of("core_mechanic", "Fighting"),
+			List.of("core_mechanic"),
+			List.of("art_style"),
+			List.of());
+
+		given(aiClient.extractGameElements(any(GameElementExtractRequest.class)))
+			.willReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(post("/games/extract-elements")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andDo(org.springframework.test.web.servlet.result.MockMvcResultHandlers.print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.elements.core_mechanic").value("Fighting"))
+			.andExpect(jsonPath("$.required_fields[0]").value("core_mechanic"))
+			.andExpect(jsonPath("$.optional_fields[0]").value("art_style"));
+	}
+
+	@Test
+	@DisplayName("POST /workspaces/{uuid}/games - 추출된 요소를 포함하여 게임 저장")
+	void createGameWithExtractedElements_Success() throws Exception {
+		// given
+		String extractedJson = "{\"core_mechanic\": \"Fighting\"}";
+		CreateGameRequest request = new CreateGameRequest(
+			"New Game",
+			List.of("ACTION"),
+			"Context",
+			extractedJson);
+
+		// when
+		mockMvc.perform(post("/workspaces/{workspaceUuid}/games", testWorkspace.getUuid())
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated());
+
+		// then
+		Optional<Game> savedGame = gameRepository.findByWorkspaceUuid(testWorkspace.getUuid()).stream()
+			.filter(g -> g.getName().equals("New Game"))
+			.findFirst();
+
+		assertThat(savedGame).isPresent();
+		assertThat(savedGame.get().getExtractedElements()).isEqualTo(extractedJson);
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #156 

## ✨ 작업 내용 (Summary)
- [x] GameElementExtractRequest/Response/Result DTO 추가
- [x] AiClient에 extractGameElements 메서드 추가
- [x] FastApiClient에서 AI 서버 /game/extract-elements 엔드포인트 호출 구현
- [x] GameController에 POST /games/extract-elements 엔드포인트 추가
- [x] GameService에서 추출 로직 연결
- [x] Game 엔티티에 extractedElements 필드 추가
- [x] CreateGameRequest에 extractedElements 필드 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

