### PR TITLE
feat: AI 질문 생성 셔플 기능 추가 및 연동 데이터 무결성 강화

### DIFF
--- a/src/main/java/com/playprobie/api/domain/game/dao/GameRepository.java
+++ b/src/main/java/com/playprobie/api/domain/game/dao/GameRepository.java
@@ -11,6 +11,10 @@ import com.playprobie.api.domain.game.domain.Game;
 public interface GameRepository extends JpaRepository<Game, Long> {
 	Optional<Game> findByUuid(UUID uuid);
 
+	Optional<Game> findByName(String name);
+
+	List<Game> findAllByName(String name);
+
 	List<Game> findByWorkspaceUuid(UUID workspaceUuid);
 
 	@org.springframework.data.jpa.repository.Query("SELECT g FROM Game g JOIN g.workspace w JOIN w.members m WHERE m.user.id = :userId")

--- a/src/main/java/com/playprobie/api/domain/interview/api/InterviewController.java
+++ b/src/main/java/com/playprobie/api/domain/interview/api/InterviewController.java
@@ -69,7 +69,9 @@ public class InterviewController {
 
 		// AI 서버에 세션 시작 요청 (비동기 SSE 스트리밍)
 		// 게임 정보와 테스터 프로필은 InterviewService에서 조회하여 전달
-		fastApiClient.streamOpening(sessionId, null, null);
+		com.playprobie.api.domain.interview.dto.SessionAiContext context = interviewService
+			.getSessionAiContext(sessionId);
+		fastApiClient.streamOpening(sessionId, context.gameInfo(), context.testerProfile());
 
 		return emitter;
 	}

--- a/src/main/java/com/playprobie/api/domain/interview/dto/SessionAiContext.java
+++ b/src/main/java/com/playprobie/api/domain/interview/dto/SessionAiContext.java
@@ -1,0 +1,13 @@
+package com.playprobie.api.domain.interview.dto;
+
+import java.util.Map;
+
+import com.playprobie.api.infra.ai.dto.request.AiSessionStartRequest;
+
+import lombok.Builder;
+
+@Builder
+public record SessionAiContext(
+	Map<String, Object> gameInfo,
+	AiSessionStartRequest.TesterProfileDto testerProfile) {
+}

--- a/src/main/java/com/playprobie/api/domain/survey/api/SurveyController.java
+++ b/src/main/java/com/playprobie/api/domain/survey/api/SurveyController.java
@@ -80,9 +80,11 @@ public class SurveyController {
 	@PostMapping("/ai-questions")
 	@Operation(summary = "AI 질문 생성", description = "AI를 통해 추천 질문 목록을 생성합니다.")
 	public ResponseEntity<CommonResponse<List<String>>> generateAiQuestions(
+		@AuthenticationPrincipal(expression = "user")
+		User user,
 		@Valid @RequestBody
 		AiQuestionsRequest request) {
-		List<String> result = surveyService.generateAiQuestions(request);
+		List<String> result = surveyService.generateAiQuestions(request, user);
 		return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.of(result));
 	}
 

--- a/src/main/java/com/playprobie/api/domain/survey/dto/request/AiQuestionsRequest.java
+++ b/src/main/java/com/playprobie/api/domain/survey/dto/request/AiQuestionsRequest.java
@@ -26,5 +26,20 @@ public record AiQuestionsRequest(
 	List<String> themePriorities,
 
 	@Schema(description = "테마별 세부 항목 (선택)", example = "{\"gameplay\": [\"core_loop\", \"fun\"], \"ui_ux\": [\"onboarding\"]}", requiredMode = Schema.RequiredMode.NOT_REQUIRED) @JsonProperty("theme_details")
-	Map<String, List<String>> themeDetails) {
+	Map<String, List<String>> themeDetails,
+
+	@Schema(description = "요청할 질문 개수 (기본값: 5)", example = "5", requiredMode = Schema.RequiredMode.NOT_REQUIRED) @JsonProperty("count")
+	Integer count,
+
+	@Schema(description = "테스트 단계 (prototype/playtest/launch)", example = "prototype", requiredMode = Schema.RequiredMode.NOT_REQUIRED) @JsonProperty("test_stage")
+	String testStage,
+
+	@Schema(description = "게임 UUID (DB 조회용)", example = "123e4567-e89b-12d3-a456-426614174000", requiredMode = Schema.RequiredMode.NOT_REQUIRED) @JsonProperty("game_uuid")
+	java.util.UUID gameUuid,
+
+	@Schema(description = "게임 핵심 요소 (template 치환용)", example = "{\"core_mechanic\": \"Deck Building\", \"player_goal\": \"Climb the Spire\"}", requiredMode = Schema.RequiredMode.NOT_REQUIRED) @JsonProperty("extracted_elements")
+	Map<String, String> extractedElements,
+
+	@Schema(description = "질문 셔플 여부 (true: 다양한 추천, false/null: 최적 매칭)", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED) @JsonProperty("shuffle")
+	Boolean shuffle) {
 }

--- a/src/main/java/com/playprobie/api/global/config/MockDataLoader.java
+++ b/src/main/java/com/playprobie/api/global/config/MockDataLoader.java
@@ -316,6 +316,8 @@ public class MockDataLoader implements CommandLineRunner {
 			.name((String)gameData.get("name"))
 			.genres(genres)
 			.context((String)gameData.get("description"))
+			.extractedElements(
+				"{\"core_mechanic\": \"숨바꼭질 및 퇴마 의식\", \"player_goal\": \"새벽 4시까지 생존하고 악령 퇴치\", \"horror_element\": \"점프스케어와 심리적 압박\", \"atmosphere\": \"어둡고 습한 폐가, 고립감\", \"main_character\": \"기억을 잃은 퇴마사\"}")
 			.build());
 		log.info("💾 [1/4] Game 저장 완료: {}, UUID={}, genres={}", game.getName(), game.getUuid(), genres);
 

--- a/src/main/java/com/playprobie/api/infra/ai/AiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/AiClient.java
@@ -33,6 +33,16 @@ public interface AiClient {
 		List<String> themePriorities, Map<String, List<String>> themeDetails);
 
 	/**
+	 * QuestionBank 기반 질문 추천
+	 * POST /api/questions/recommend
+	 *
+	 * @param request 질문 추천 요청
+	 * @return 추천된 질문 목록
+	 */
+	com.playprobie.api.infra.ai.dto.response.QuestionRecommendResponse recommendQuestions(
+		com.playprobie.api.infra.ai.dto.request.QuestionRecommendRequest request);
+
+	/**
 	 * 질문 피드백 기반 대안 생성
 	 * POST /fixed-questions/feedback
 	 *

--- a/src/main/java/com/playprobie/api/infra/ai/dto/request/QuestionRecommendRequest.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/request/QuestionRecommendRequest.java
@@ -1,0 +1,28 @@
+package com.playprobie.api.infra.ai.dto.request;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+/**
+ * FastAPI /api/questions/recommend 요청 DTO
+ */
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record QuestionRecommendRequest(
+	String gameName,
+	String gameDescription,
+	List<String> genres,
+	String testPhase,
+	List<String> purposeCategories,
+	List<String> purposeSubcategories,
+	Map<String, String> extractedElements,
+	Object adoptionStats,
+	Integer topK,
+	Object scoringWeights,
+	Boolean shuffle) {
+}

--- a/src/main/java/com/playprobie/api/infra/ai/dto/response/QuestionRecommendResponse.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/response/QuestionRecommendResponse.java
@@ -1,0 +1,20 @@
+package com.playprobie.api.infra.ai.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+/**
+ * FastAPI /api/questions/recommend 응답 DTO
+ */
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record QuestionRecommendResponse(
+	List<RecommendedQuestion> questions,
+	Integer totalCandidates,
+	Map<String, Double> scoringWeightsUsed) {
+}

--- a/src/main/java/com/playprobie/api/infra/ai/dto/response/RecommendedQuestion.java
+++ b/src/main/java/com/playprobie/api/infra/ai/dto/response/RecommendedQuestion.java
@@ -1,0 +1,26 @@
+package com.playprobie.api.infra.ai.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+/**
+ * 추천된 개별 질문 DTO
+ */
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record RecommendedQuestion(
+	String id,
+	String text,
+	String originalText,
+	String template,
+	String slotKey,
+	String purposeCategory,
+	String purposeSubcategory,
+	Double similarityScore,
+	Double goalMatchScore,
+	Double adoptionRate,
+	Double finalScore,
+	Object embedding) {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #158 

## ✨ 작업 내용 (Summary)
- **AI 질문 생성 셔플(shuffle) 옵션 추가**
  - [AiQuestionsRequest](cci:2://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/domain/survey/dto/request/AiQuestionsRequest.java:12:0-44:1) 및 [QuestionRecommendRequest](cci:2://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/infra/ai/dto/request/QuestionRecommendRequest.java:13:0-27:1)에 `shuffle` 필드 추가
  - 요청 시 `shuffle=true`일 경우 AI가 다양한 추천 결과를 반환하도록 지원

- **AI 세션 시작 요청([streamOpening](cci:1://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java:797:1-824:2)) 데이터 무결성 강화**
  - 기존에 `null`로 전달되던 `game_info`와 `tester_profile`을 정상적으로 전달하도록 수정
  - [InterviewService](cci:2://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/domain/interview/application/InterviewService.java:36:0-472:1)에 [getSessionAiContext](cci:1://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/domain/interview/application/InterviewService.java:426:1-471:2) 메서드를 구현하여 필요한 컨텍스트 데이터 조회 및 매핑

- **AI 질문 생성 안정성 개선**
  - **422 에러 방지**: `extracted_elements`가 `null`일 경우 AI 서버 에러를 방지하기 위해 빈 객체(`{}`)를 전송하도록 수정
  - **중복 게임 이름 처리**: `gameName`으로 조회 시 중복된 결과([findByName](cci:1://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/domain/game/dao/GameRepository.java:13:1-13:40) 에러)가 발생하지 않도록 [findAllByName](cci:1://file:///Users/nobbkim/PlayProbie/server/src/main/java/com/playprobie/api/domain/game/dao/GameRepository.java:15:1-15:39)을 사용하여 최신 게임 정보를 우선 사용하도록 개선

- **테스트 코드 수정 및 검증**
  - 변경된 로직(DTO 수정, 메서드 시그니처 변경)에 맞춰 `SurveyServiceTest` 수정
  - Stash pop 과정에서 발생한 테스트 파일 손상 복구

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?
