### PR TITLE
fix: 인사이트 질문 무한 반복 버그 수정

### DIFF
--- a/src/main/java/com/playprobie/api/domain/replay/application/InsightQuestionService.java
+++ b/src/main/java/com/playprobie/api/domain/replay/application/InsightQuestionService.java
@@ -69,6 +69,16 @@ public class InsightQuestionService {
 		// 랜덤으로 최대 2개 선택
 		List<AnalysisTag> selectedTags = insightQuestionGenerator.selectRandomInsights(allTags);
 
+		// 선택된 태그 마킹 및 비선택 태그 스킵 처리
+		for (AnalysisTag tag : allTags) {
+			if (selectedTags.contains(tag)) {
+				tag.markAsSelected();
+			} else {
+				tag.markAsSkipped();
+			}
+		}
+		analysisTagRepository.saveAll(allTags);
+
 		log.info("[InsightQuestionService] Starting insight phase: session={}, selected={}/{}",
 			sessionUuid, selectedTags.size(), allTags.size());
 
@@ -97,9 +107,9 @@ public class InsightQuestionService {
 		log.info("[InsightQuestionService] Answer saved: tagId={}, type={}",
 			tagId, tag.getInsightType());
 
-		// 남은 인사이트 질문 확인
+		// 남은 인사이트 질문 확인 (선택된 태그 중에서만)
 		UUID uuid = UUID.fromString(sessionUuid);
-		List<AnalysisTag> remainingTags = analysisTagRepository.findBySessionUuidAndIsAskedFalse(uuid);
+		List<AnalysisTag> remainingTags = analysisTagRepository.findBySessionUuidAndIsSelectedTrueAndIsAskedFalse(uuid);
 
 		if (remainingTags.isEmpty()) {
 			// 모든 인사이트 질문 완료
@@ -133,9 +143,9 @@ public class InsightQuestionService {
 		log.info("[InsightQuestionService] Answer saved: tagId={}, type={}",
 			tagId, tag.getInsightType());
 
-		// 남은 인사이트 질문 확인
+		// 남은 인사이트 질문 확인 (선택된 태그 중에서만)
 		UUID uuid = UUID.fromString(sessionUuid);
-		List<AnalysisTag> remainingTags = analysisTagRepository.findBySessionUuidAndIsAskedFalse(uuid);
+		List<AnalysisTag> remainingTags = analysisTagRepository.findBySessionUuidAndIsSelectedTrueAndIsAskedFalse(uuid);
 
 		if (remainingTags.isEmpty()) {
 			// 모든 인사이트 질문 완료 - SSE 이벤트 전송 및 완료 응답 반환

--- a/src/main/java/com/playprobie/api/domain/replay/dao/AnalysisTagRepository.java
+++ b/src/main/java/com/playprobie/api/domain/replay/dao/AnalysisTagRepository.java
@@ -26,4 +26,14 @@ public interface AnalysisTagRepository extends JpaRepository<AnalysisTag, Long> 
 	 * 세션 ID로 모든 태그 조회
 	 */
 	List<AnalysisTag> findBySessionId(Long sessionId);
+
+	/**
+	 * 세션 ID로 선택된 태그 중 아직 질문하지 않은 태그 조회
+	 */
+	List<AnalysisTag> findBySessionIdAndIsSelectedTrueAndIsAskedFalse(Long sessionId);
+
+	/**
+	 * 세션 UUID로 선택된 태그 중 아직 질문하지 않은 태그 조회
+	 */
+	List<AnalysisTag> findBySessionUuidAndIsSelectedTrueAndIsAskedFalse(UUID sessionUuid);
 }

--- a/src/main/java/com/playprobie/api/domain/replay/domain/AnalysisTag.java
+++ b/src/main/java/com/playprobie/api/domain/replay/domain/AnalysisTag.java
@@ -66,6 +66,13 @@ public class AnalysisTag extends BaseTimeEntity {
 	@Column(name = "is_asked", nullable = false)
 	private Boolean isAsked = false;
 
+	/**
+	 * 인사이트 질문 대상으로 선택되었는지 여부
+	 * startInsightQuestionPhase에서 랜덤 선택 시 true로 설정
+	 */
+	@Column(name = "is_selected", nullable = false)
+	private Boolean isSelected = false;
+
 	@Column(name = "answer_text", columnDefinition = "TEXT")
 	private String answerText;
 
@@ -78,6 +85,7 @@ public class AnalysisTag extends BaseTimeEntity {
 		this.durationMs = durationMs;
 		this.metadata = metadata;
 		this.isAsked = false;
+		this.isSelected = false;
 	}
 
 	/**
@@ -86,5 +94,21 @@ public class AnalysisTag extends BaseTimeEntity {
 	public void markAsAsked(String answerText) {
 		this.isAsked = true;
 		this.answerText = answerText;
+	}
+
+	/**
+	 * 인사이트 질문 대상으로 선택
+	 */
+	public void markAsSelected() {
+		this.isSelected = true;
+	}
+
+	/**
+	 * 인사이트 질문 대상에서 제외 (스킵 처리)
+	 * isAsked=true로 설정하여 향후 조회에서 제외
+	 */
+	public void markAsSkipped() {
+		this.isAsked = true;
+		this.answerText = null;
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #167 

## ✨ 작업 내용 (Summary)
- [x] `AnalysisTag` 엔티티에 `isSelected` 필드 추가
- [x] `startInsightQuestionPhase`에서 선택된 태그만 `isSelected=true`로 마킹
- [x] 비선택 태그는 즉시 `isAsked=true`로 스킵 처리
- [x] `processInsightAnswer`에서 선택된 태그만 조회하도록 쿼리 변경


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

