### PR TITLE
fix: SSE 연결 끊김(Race Condition) 및 좀비 스트림 문제 해결

### DIFF
--- a/src/main/java/com/playprobie/api/infra/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/com/playprobie/api/infra/sse/repository/SseEmitterRepository.java
@@ -21,19 +21,19 @@ public class SseEmitterRepository {
 
 		emitter.onCompletion(() -> {
 			log.info("SSE Connection Completed. Removing SessionId: {}", sessionId);
-			this.deleteById(sessionId);
+			this.delete(sessionId, emitter);
 		});
 
 		emitter.onTimeout(() -> {
 			log.warn("SSE Connection Timed Out. Removing SessionId: {}", sessionId);
 			emitter.complete();
-			this.deleteById(sessionId);
+			this.delete(sessionId, emitter);
 		});
 
 		emitter.onError((e) -> {
 			log.error("SSE Connection Error. SessionId: {}", sessionId, e);
 			emitter.complete();
-			this.deleteById(sessionId);
+			this.delete(sessionId, emitter);
 		});
 
 		return emitter;
@@ -45,5 +45,13 @@ public class SseEmitterRepository {
 
 	public void deleteById(String sessionId) {
 		emitters.remove(sessionId);
+	}
+
+	public void delete(String sessionId, SseEmitter emitter) {
+		if (emitters.remove(sessionId, emitter)) {
+			log.info("SSE Emitter safely removed. SessionId: {}", sessionId);
+		} else {
+			log.debug("SSE Emitter removal skipped (already replaced or removed). SessionId: {}", sessionId);
+		}
 	}
 }


### PR DESCRIPTION

## 📌 관련 이슈
- Closes #175 

## ✨ 작업 내용 (Summary)
- SSE Emitter 삭제 시 Race Condition으로 인해 정상적인 새 연결이 끊어지는 문제 해결
  - SseEmitterRepository에 safe delete() 도입
  - 기존 deleteById 대신 특정 Emitter 객체를 확인 후 삭제하도록 로직 변경
- 클라이언트 연결 종료 시 서버에서 AI 스트림이 계속 유지되는(Zombie Stream) 문제 해결
  - SseEmitterService.send() 반환값(boolean)으로 전송 성공 여부 확인
  - 전송 실패 시 SseConnectionClosedException 발생시켜 Flux 스트림 즉시 중단


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

