### PR TITLE
refactor: 인사이트 분석 및 세션 종료 로직 개선

### DIFF
--- a/src/main/java/com/playprobie/api/domain/replay/application/InputLogAnalyzer.java
+++ b/src/main/java/com/playprobie/api/domain/replay/application/InputLogAnalyzer.java
@@ -26,7 +26,8 @@ public class InputLogAnalyzer {
 	private static final int PANIC_THRESHOLD_MS = 500;
 	private static final int PANIC_KEY_COUNT = 5;
 
-	// Idle: 10초(10_000ms) 이상 입력 없음
+	// Idle: 30초(30_000ms) 이후부터 10초(10_000ms) 이상 입력 없으면 감지
+	private static final int IDLE_START_THRESHOLD_MS = 30_000;
 	private static final int IDLE_THRESHOLD_MS = 10_000;
 
 	// Panic 감지 시 구간 길이 (기본 3초)
@@ -124,7 +125,7 @@ public class InputLogAnalyzer {
 	}
 
 	/**
-	 * Idle 감지: 10초 이상 입력 없음 (media_time 간격 기준)
+	 * Idle 감지: 30초 이후부터 10초 이상 입력 없음 (media_time 간격 기준)
 	 */
 	private List<AnalysisTag> detectIdle(SurveySession session, List<InputLogDto> allLogs) {
 		List<AnalysisTag> idleTags = new ArrayList<>();
@@ -133,9 +134,10 @@ public class InputLogAnalyzer {
 			return idleTags;
 		}
 
-		// 입력 이벤트만 필터링
+		// 입력 이벤트만 필터링 (30초 이후의 이벤트만 대상)
 		List<InputLogDto> inputEvents = allLogs.stream()
 			.filter(InputLogDto::isInputEvent)
+			.filter(log -> log.mediaTime() >= IDLE_START_THRESHOLD_MS)
 			.toList();
 
 		if (inputEvents.size() < 2) {

--- a/src/main/java/com/playprobie/api/domain/replay/application/InsightQuestionService.java
+++ b/src/main/java/com/playprobie/api/domain/replay/application/InsightQuestionService.java
@@ -52,7 +52,7 @@ public class InsightQuestionService {
 
 	/**
 	 * 인사이트 질문 Phase 시작
-	 * 랜덤으로 최대 1개 선택하여 질문 전송
+	 * 가장 마지막 태그 1개만 선택하여 질문 전송
 	 *
 	 * @return 시작 성공 여부 (인사이트 없으면 false)
 	 */
@@ -69,8 +69,9 @@ public class InsightQuestionService {
 			return false;
 		}
 
-		// 랜덤으로 최대 1개 선택
-		List<AnalysisTag> selectedTags = insightQuestionGenerator.selectRandomInsights(allTags);
+		// 가장 마지막 태그 1개만 선택
+		AnalysisTag lastTag = allTags.get(allTags.size() - 1);
+		List<AnalysisTag> selectedTags = List.of(lastTag);
 
 		// 선택된 태그 마킹 및 비선택 태그 스킵 처리
 		for (AnalysisTag tag : allTags) {

--- a/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java
+++ b/src/main/java/com/playprobie/api/infra/ai/impl/FastApiClient.java
@@ -376,7 +376,7 @@ public class FastApiClient implements AiClient {
 
 				if (shouldEnd) {
 					log.info("🛑 [SHOULD_END] AI recommends ending session. reason={}", endReason);
-					streamClosing(sessionId, endReason != null ? endReason : AiConstants.REASON_FATIGUE);
+					proceedToClosingOrInsight(sessionId, endReason != null ? endReason : AiConstants.REASON_FATIGUE);
 					return true;
 				}
 

--- a/src/test/java/com/playprobie/api/domain/replay/application/InputLogAnalyzerTest.java
+++ b/src/test/java/com/playprobie/api/domain/replay/application/InputLogAnalyzerTest.java
@@ -112,12 +112,12 @@ class InputLogAnalyzerTest {
 	class IdleDetection {
 
 		@Test
-		@DisplayName("10초 이상 입력 없음 시 Idle 감지")
+		@DisplayName("30초 이후부터 10초 이상 입력 없음 시 Idle 감지")
 		void detectIdle_whenNoInputForTenSeconds() {
-			// given: 0초에 입력, 15초에 다음 입력 (15초 gap)
+			// given: 30초에 입력, 45초에 다음 입력 (15초 gap) - 30초 이후부터 Idle 감지 대상
 			List<InputLogDto> logs = List.of(
-				createKeyDownLog("Space", " ", 0L),
-				createKeyDownLog("Space", " ", 15000L));
+				createKeyDownLog("Space", " ", 30000L),
+				createKeyDownLog("Space", " ", 45000L));
 
 			// when
 			List<AnalysisTag> tags = inputLogAnalyzer.analyze(mockSession, logs);
@@ -144,13 +144,13 @@ class InputLogAnalyzerTest {
 		}
 
 		@Test
-		@DisplayName("여러 Idle 구간 감지")
+		@DisplayName("30초 이후 여러 Idle 구간 감지")
 		void detectMultipleIdles() {
-			// given: 두 개의 15초 gap
+			// given: 30초 이후부터 두 개의 15초 gap
 			List<InputLogDto> logs = List.of(
-				createKeyDownLog("Space", " ", 0L),
-				createKeyDownLog("Space", " ", 15000L),
-				createKeyDownLog("Space", " ", 30000L));
+				createKeyDownLog("Space", " ", 30000L),
+				createKeyDownLog("Space", " ", 45000L),
+				createKeyDownLog("Space", " ", 60000L));
 
 			// when
 			List<AnalysisTag> tags = inputLogAnalyzer.analyze(mockSession, logs);
@@ -205,14 +205,15 @@ class InputLogAnalyzerTest {
 		@Test
 		@DisplayName("Panic과 Idle 동시 감지")
 		void detectBothPanicAndIdle() {
-			// given: Panic 후 15초 대기
+			// given: Panic 후 30초 이후 15초 대기
 			List<InputLogDto> logs = new ArrayList<>();
-			// Panic: 0-400ms
+			// Panic: 0-400ms (30초 이전이므로 Idle 감지 대상 아님)
 			for (int i = 0; i < 5; i++) {
 				logs.add(createKeyDownLog("Space", " ", i * 100L));
 			}
-			// Idle: 400ms -> 15400ms (15초 gap)
-			logs.add(createKeyDownLog("Enter", "\n", 15400L));
+			// 30초 이후 시작하는 Idle 구간: 30000ms -> 45000ms (15초 gap)
+			logs.add(createKeyDownLog("Enter", "\n", 30000L));
+			logs.add(createKeyDownLog("Enter", "\n", 45000L));
 
 			// when
 			List<AnalysisTag> tags = inputLogAnalyzer.analyze(mockSession, logs);


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #180 

## ✨ 작업 내용 (Summary)
- [x] Idle 감지를 30초 이후부터 시작하도록 변경
- [x] 인사이트 질문 선택 시 랜덤 대신 마지막 태그만 선택
- [x] 세션 종료 시 insight phase 고려하도록 수정


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

