### PR TITLE
fix: 설문 세부 데이터 조회 시 completed 상태만 정보 전달하도록 수정

### DIFF
--- a/src/main/java/com/playprobie/api/domain/interview/dao/SurveySessionRepository.java
+++ b/src/main/java/com/playprobie/api/domain/interview/dao/SurveySessionRepository.java
@@ -59,4 +59,21 @@ public interface SurveySessionRepository extends JpaRepository<SurveySession, Lo
 		@Param("cursor")
 		Long cursor,
 		Pageable pageable);
+
+	@Query("""
+		SELECT ss FROM SurveySession ss
+		JOIN FETCH ss.survey s
+		WHERE s.id = :surveyId
+		AND ss.status = :status
+		AND (:cursor IS NULL OR ss.id < :cursor)
+		ORDER BY ss.id DESC
+		""")
+	List<SurveySession> findBySurveyIdAndStatusWithCursor(
+		@Param("surveyId")
+		Long surveyId,
+		@Param("status")
+		SessionStatus status,
+		@Param("cursor")
+		Long cursor,
+		Pageable pageable);
 }

--- a/src/main/java/com/playprobie/api/domain/survey/application/SurveyResultService.java
+++ b/src/main/java/com/playprobie/api/domain/survey/application/SurveyResultService.java
@@ -55,10 +55,10 @@ public class SurveyResultService {
 		return getSummary(survey.getId(), status);
 	}
 
-	// 전체 응답 리스트 (커서 페이징)
+	// 전체 응답 리스트 (커서 페이징) - COMPLETED 상태만 조회
 	public SurveyResultListResponse getResponseList(long surveyId, Long cursor, int size) {
-		List<SurveySession> sessions = sessionRepository.findBySurveyIdWithCursor(
-			surveyId, cursor, PageRequest.of(0, size + 1));
+		List<SurveySession> sessions = sessionRepository.findBySurveyIdAndStatusWithCursor(
+			surveyId, SessionStatus.COMPLETED, cursor, PageRequest.of(0, size + 1));
 
 		boolean hasNext = sessions.size() > size;
 		if (hasNext) {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #182 

## ✨ 작업 내용 (Summary)
- [x] status 필터링 쿼리를 추가한 findBySurveyIdAndStatusWithCursor 구현
- [x] SurveyResultListResponse에서 completed 상태만 필터링해서 조회하도록 수정


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

